### PR TITLE
contracts: add Exodus evidence-fabric contract bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ validate-examples:
 	python3 scripts/validate_examples.py
 
 validate-evidence-fabric-contracts:
-	python3 scripts/validate_evidence_fabric_contracts.py
+	python3 scripts/validate_exodus_evidence_fabric_all.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: validate validate-examples validate-evidence-fabric-contracts
+
+validate: validate-examples validate-evidence-fabric-contracts
+	@echo "OK: validate"
+
+validate-examples:
+	python3 scripts/validate_examples.py
+
+validate-evidence-fabric-contracts:
+	python3 scripts/validate_evidence_fabric_contracts.py

--- a/backlog/evidence-fabric-dashboard-backlog.md
+++ b/backlog/evidence-fabric-dashboard-backlog.md
@@ -1,0 +1,172 @@
+# Evidence Fabric Dashboard Backlog
+
+## Status
+
+Planned Exodus Dashboard workstream.
+
+## Purpose
+
+This backlog maps the evidence-fabric contracts in this branch to user-facing dashboard panels and actions. The goal is to accelerate user exodus from closed vendor control surfaces by making migration state, blockers, proof, and next actions visible.
+
+## Contract inputs
+
+- `EvidenceDashboardState`
+- `MigrationWavePlan`
+- `ProofPackSummary`
+- `NotesSourceProfile`
+
+## Dashboard panels
+
+### 1. Provider control overview
+
+Shows Apple, Google, Microsoft, and later providers with:
+
+- Provider Control Surface score
+- Exit Readiness Index
+- discovered assets
+- migrated unique bytes
+- duplicate bytes eliminated
+- blocked objects
+- proof packs generated
+
+Primary actions:
+
+- inspect provider topology
+- start a migration wave
+- view blockers
+- export provider-status report
+
+### 2. Migration wave planner
+
+Shows one row per planned wave:
+
+- provider
+- source type
+- selection
+- estimated objects
+- estimated bytes
+- target object store
+- parser routes
+- delete-source policy
+- mirror parity requirement
+- cooling-off requirement
+
+Primary actions:
+
+- create wave
+- pause wave
+- resume wave
+- mark wave blocked
+- generate proof pack after validation
+
+### 3. Evidence landing monitor
+
+Shows broker-derived state:
+
+- acquisition runs
+- raw blobs landed
+- unique bytes landed
+- source aliases preserved
+- parser success/failure counts
+- validation status
+
+Primary actions:
+
+- inspect acquisition run
+- inspect duplicate cluster
+- inspect source alias report
+- retry parser
+- export manifest summary
+
+### 4. Notes migration panel
+
+Shows Google Keep, iCloud Notes, and OneNote as first-class note surfaces.
+
+For each provider, show:
+
+- notes discovered
+- notes landed
+- notes with attachments
+- notes blocked or partially exported
+- rich text derivatives created
+- OCR/transcript derivatives created
+- open-format conversions
+
+Primary actions:
+
+- inspect notes-source profile
+- start notes wave
+- review blocked notes
+- export notes proof pack
+
+### 5. Proof-pack center
+
+Shows proof packs by migration wave:
+
+- status
+- manifest refs
+- validation refs
+- source alias report
+- mirror parity report
+- blocked object report
+- open-format conversion report
+- source deletion eligibility
+- provider downgrade eligibility
+
+Primary actions:
+
+- generate proof pack
+- validate proof pack
+- export user-readable report
+- export machine-readable report
+- start cooling-off window
+
+### 6. Blockers and next actions
+
+Aggregates blockers across all providers and waves.
+
+Primary categories:
+
+- mirror parity pending
+- manifest parity pending
+- unsupported export format
+- locked note or encrypted object
+- API quota or provider limitation
+- parser failure
+- missing source alias metadata
+- cooling-off not complete
+
+Primary actions:
+
+- filter by provider
+- filter by severity
+- assign remediation wave
+- export blocker report
+
+## User workflow
+
+1. Connect a source account or select a local export.
+2. Preview provider topology and estimated size.
+3. Create a migration wave.
+4. Land raw content into canonical evidence storage.
+5. Review dedupe and source aliases.
+6. Process text, log, document, note, media, and attachment derivatives.
+7. Review blockers and next actions.
+8. Generate proof pack.
+9. Start cooling-off window.
+10. Mark source provider retained, downgraded, or deletion-eligible.
+
+## Non-goals
+
+- No provider deletion by default.
+- No raw provider API authority after custody is established.
+- No graph projection as the canonical system of record.
+- No silent dedupe that erases source aliases.
+
+## Next implementation slices
+
+1. Render static dashboard cards from the example fixtures.
+2. Add fixture-backed tests for dashboard-state parsing.
+3. Add proof-pack summary download surface.
+4. Add notes-provider wave creation panel.
+5. Connect to evidence broker state after broker repo exists.

--- a/backlog/provider-coverage-roadmap.md
+++ b/backlog/provider-coverage-roadmap.md
@@ -1,0 +1,226 @@
+# Provider Coverage Roadmap
+
+## Status
+
+Backlog for world-class Exodus provider coverage.
+
+## Purpose
+
+Exodus should become the open migration, evidence, and sovereignty layer for every major closed or semi-closed user data surface. Provider coverage should expand in waves, but the architecture must assume that all providers are eventual ingress surfaces.
+
+The rule remains stable:
+
+- source systems are ingress only,
+- raw custody happens before parsing or conversion,
+- provider IDs and paths are source aliases,
+- user attestation and policy gates are evidence records,
+- normalization produces open derived records,
+- proof packs show what was captured, converted, blocked, or left behind.
+
+## Coverage waves
+
+### Wave 0: Core personal cloud exits
+
+- Apple iCloud Drive
+- Apple iCloud Photos
+- Apple Notes / iCloud Notes
+- Apple Mail / iCloud Mail
+- Apple Music local library / iTunes library exports
+- Google Drive
+- Google Photos
+- Google Keep
+- Gmail / Google Takeout Mail
+- Google Calendar and Contacts
+- Microsoft OneDrive
+- Microsoft Outlook / Exchange / Microsoft 365 Mail
+- Microsoft OneNote
+- Microsoft Teams export surfaces where available
+
+### Wave 1: AI chat and assistant exports
+
+- ChatGPT / OpenAI
+- Claude / Anthropic
+- Gemini / Google
+- Copilot / Microsoft
+- Perplexity
+- Poe
+- Mistral Le Chat
+- xAI Grok
+- Meta AI exports where available
+- local assistant logs
+- Ollama / LM Studio / local inference chat logs
+- IDE assistant logs from Cursor, Windsurf, Copilot Chat, Continue, and similar tools
+- enterprise support-bot exports where users/admins are authorized
+
+### Wave 2: Email, calendar, contacts, and identity-adjacent data
+
+- generic IMAP
+- generic SMTP archive exports
+- MBOX
+- Maildir
+- EML folders
+- Proton Mail exports where available
+- Fastmail exports
+- Yahoo Mail exports
+- Zoho Mail exports
+- Exchange archives
+- CardDAV contacts
+- CalDAV calendars
+- ICS calendar exports
+- vCard contact exports
+
+### Wave 3: Notes, documents, knowledge bases, and writing systems
+
+- Notion
+- Evernote
+- Obsidian vaults
+- Joplin
+- Standard Notes
+- Apple Pages / Numbers / Keynote exports
+- Microsoft Word / Excel / PowerPoint documents
+- Google Docs / Sheets / Slides exports
+- Dropbox Paper
+- Box Notes
+- Confluence
+- Coda
+- Quip
+- Markdown folders
+- local wiki exports
+
+### Wave 4: Messaging, collaboration, and social workspaces
+
+- Slack
+- Discord
+- Microsoft Teams
+- Matrix
+- Telegram export archives
+- Signal local export paths where available and authorized
+- WhatsApp export archives
+- iMessage local export paths where available and authorized
+- Google Chat
+- Zoom chat/transcripts/cloud recordings where exportable
+- Mattermost
+- Zulip
+
+### Wave 5: Media libraries and creative assets
+
+- local music libraries
+- local video libraries
+- Apple Photos libraries
+- Google Photos exports
+- Adobe Lightroom exports
+- Adobe Creative Cloud files where exportable
+- DaVinci Resolve projects
+- Final Cut Pro projects
+- Logic Pro projects
+- GarageBand projects
+- Audacity projects
+- camera SD card exports
+- podcast project folders
+- Plex / Jellyfin metadata and libraries
+
+### Wave 6: Developer and technical work history
+
+- GitHub repositories, issues, PRs, discussions, releases, actions artifacts
+- GitLab projects
+- Bitbucket projects
+- Jira projects
+- Linear issues
+- Azure DevOps projects
+- CI/CD logs
+- local shell histories where user-authorized
+- terminal transcripts
+- browser console captures
+- device console captures
+- package registry metadata
+- container image manifests
+
+### Wave 7: Financial, legal, medical, and administrative archives
+
+- bank statement exports
+- brokerage statement exports
+- tax archives
+- invoices and receipts
+- legal document folders
+- medical record exports where user-authorized
+- insurance documents
+- government portal exports
+- signed PDFs
+- scanned archives
+
+These surfaces require stronger redaction, local-only defaults, and proof-pack controls.
+
+### Wave 8: Social media and creator platforms
+
+- X/Twitter data archive
+- Facebook data archive
+- Instagram data archive
+- TikTok data archive
+- YouTube Studio exports
+- Substack exports
+- Medium exports
+- Patreon creator/member exports where available
+- Mastodon export archives
+- Bluesky export paths where available
+
+## Cross-cutting provider object types
+
+Every provider should be mapped into these canonical migration object families:
+
+- SourceProfile
+- MigrationWavePlan
+- EvidenceDashboardState
+- ProofPackSummary
+- SourceAliasReport
+- BlockedObjectReport
+- ConversionProfile
+- ConversionReceipt
+- AttestationRecord
+- RedactionReviewRecord
+- DeletionEligibilityRecord
+- ProviderDowngradePlan
+
+## Missing contract families
+
+The current PR has strong starts for dashboard, migration wave, proof pack, notes, owned media, playlist, and AI chat exports. The next missing contract families are:
+
+- EmailSourceProfile
+- CalendarSourceProfile
+- ContactSourceProfile
+- MessageThreadDocument
+- ChatConversationReusePolicy
+- RedactionReviewRecord
+- SourceAliasReport
+- BlockedObjectReport
+- ConversionReceipt
+- ProviderTopologySnapshot
+- ProviderControlSurfaceReport
+- DeletionEligibilityRecord
+- ProviderDowngradePlan
+
+## Provider onboarding checklist
+
+For each new provider, Exodus should capture:
+
+1. source account or export method,
+2. export artifact format,
+3. raw custody path,
+4. expected metadata,
+5. attachment/media handling,
+6. redaction risk,
+7. conversion targets,
+8. blocked states,
+9. proof-pack outputs,
+10. provider downgrade or deletion eligibility gates.
+
+## Acceptance rule
+
+A provider is not considered covered until Exodus can:
+
+- preserve raw source artifacts,
+- enumerate source aliases,
+- normalize at least one useful derived record,
+- report blocked objects,
+- emit dashboard state,
+- emit proof-pack summary,
+- and explain whether provider downgrade/deletion is safe, blocked, or unknown.

--- a/docs/ai-chat-export-ingest.md
+++ b/docs/ai-chat-export-ingest.md
@@ -1,0 +1,121 @@
+# AI Chat Export Ingest Plan
+
+## Status
+
+Planned Exodus / evidence-fabric integration surface.
+
+## Purpose
+
+AI chat histories are now critical personal and professional knowledge assets. Exodus must support migration, preservation, indexing, and document conversion for AI chat exports so users are not locked into a single assistant or provider UI.
+
+This document defines the first ingest plan for ChatGPT/OpenAI and Claude/Anthropic chat exports, with room for later provider additions.
+
+## Initial provider surfaces
+
+### ChatGPT / OpenAI
+
+Expected source path:
+
+- provider data export archive,
+- chat history HTML and structured export files where present,
+- shared conversation export data where included,
+- user-provided archive folders.
+
+### Claude / Anthropic
+
+Expected source path:
+
+- provider data export archive,
+- conversation history and account export files,
+- workspace or organization export where the user is an authorized owner/admin,
+- user-provided archive folders.
+
+## Custody rules
+
+1. Preserve the raw provider export archive as an immutable evidence blob.
+2. Preserve each source file from the archive as raw or derived evidence according to extraction policy.
+3. Treat provider IDs, conversation IDs, project/workspace IDs, shared-link IDs, filenames, and archive paths as source aliases.
+4. Convert each conversation into a normalized document record.
+5. Preserve attachments, generated files, code blocks, images, and tool outputs as linked blobs or derived records where available.
+6. Chunk large conversations after raw custody and document normalization.
+7. Do not treat model responses as verified truth; they are conversation records.
+
+## Normalized conversation document
+
+Each chat thread should become a document-like record with:
+
+- provider,
+- export source profile,
+- conversation ID,
+- title,
+- created/updated timestamps where available,
+- participant roles,
+- message count,
+- token or character count where computed,
+- attachment refs,
+- source alias refs,
+- raw evidence refs,
+- normalized text derivative refs,
+- chunk refs,
+- redaction status,
+- search/index status.
+
+## Output derivatives
+
+First-pass derivatives:
+
+- Markdown document per conversation,
+- JSON document record per conversation,
+- JSONL message stream per conversation,
+- optional PDF/HTML render later,
+- chunk manifests for search/vector pipelines.
+
+## New chat integration
+
+The goal is not only archival. Exodus should prepare conversations for reuse in open chat/workspace surfaces.
+
+New chat integration should support:
+
+- importing old conversations as read-only documents,
+- citing old conversation chunks in new chats,
+- linking attachments and generated artifacts,
+- preserving provenance and source-provider context,
+- marking migrated assistant outputs as historical records, not current model claims.
+
+## Dashboard behavior
+
+Exodus Dashboard should show:
+
+- chat export archives landed,
+- conversations discovered,
+- conversations normalized,
+- attachments preserved,
+- large conversations chunked,
+- blocked or malformed conversations,
+- conversations ready for search,
+- conversations ready for document export,
+- conversations available to new chat/workspace integration.
+
+## Privacy and redaction
+
+AI chat exports may include secrets, credentials, personal records, legal/medical/financial details, and third-party information.
+
+Default posture:
+
+- preserve raw privately,
+- do not publish by default,
+- run optional secret/PII scans before proof-pack export,
+- support redacted derivative documents,
+- preserve the relationship between redacted derivatives and raw originals.
+
+## Non-goals
+
+- no provider account merge claim,
+- no claim that imported chats recreate native provider history,
+- no silent publication of private conversations,
+- no treating model outputs as authoritative facts,
+- no flattening attachments or generated files into untraceable text.
+
+## Later provider candidates
+
+Later candidates may include Gemini, Copilot, Perplexity, Poe, local assistant logs, IDE assistant chats, support bots, and enterprise assistant exports after current export paths are verified.

--- a/docs/evidence-fabric-integration.md
+++ b/docs/evidence-fabric-integration.md
@@ -1,0 +1,135 @@
+# Evidence Fabric Dashboard Integration
+
+## Status
+
+Planned consumer contract for Exodus Dashboard and Exodus Engine.
+
+## Purpose
+
+Exodus is the user-facing migration, evidence, and sovereignty surface for moving out of closed vendor control surfaces. The evidence fabric provides the custody, hashing, dedupe, source alias, parsing, validation, and proof-pack substrate behind that experience.
+
+This document defines how Exodus consumes evidence-fabric state without becoming the raw custody system itself.
+
+## Core user promise
+
+Exodus should help users answer:
+
+- what is trapped in Apple, Google, Microsoft, or another provider,
+- what has been safely landed into our own repository,
+- what is duplicated,
+- what is blocked,
+- what has been normalized into open formats,
+- what is eligible for provider downgrade or deletion after validation,
+- and what proof exists for every migration wave.
+
+## Integration surfaces
+
+### 1. Provider topology and source census
+
+Exodus consumes connector and acquisition summaries to display:
+
+- provider accounts,
+- source drives,
+- folders and major asset families,
+- estimated object counts,
+- estimated byte sizes,
+- source API/export limitations,
+- confidence gaps.
+
+### 2. Migration wave planner
+
+Exodus groups source material into migration waves:
+
+- local files,
+- Google Drive,
+- iCloud Drive,
+- email,
+- notes and mobile exports,
+- browser and terminal captures,
+- office documents,
+- media.
+
+Each wave records scope, expected size, target storage, planned parser/chunker routes, and rollback/cooling-off rules.
+
+### 3. Evidence landing progress
+
+Exodus displays broker state:
+
+- acquisition runs,
+- raw blobs landed,
+- unique bytes landed,
+- duplicate bytes eliminated,
+- source aliases preserved,
+- parser successes and failures,
+- validation status.
+
+### 4. Dedupe and source alias review
+
+Exodus must show dedupe as proof, not as destructive cleanup.
+
+If five source paths point to one SHA-256 blob, Exodus should display one canonical blob and five preserved source aliases.
+
+### 5. Processing and enrichment queue
+
+Exodus tracks derived processing state:
+
+- parsed text,
+- chunk windows,
+- OCR/transcript derivatives,
+- entity and timeline extraction,
+- format conversion,
+- rejected or unsupported objects.
+
+### 6. Proof-pack export
+
+Exodus consumes validation and manifest records to export:
+
+- migration wave proof packs,
+- source alias reports,
+- mirror parity reports,
+- source deletion eligibility reports,
+- blocked-object reports,
+- open-format conversion summaries.
+
+## Provider posture
+
+Apple, Google, Microsoft, and similar providers are ingress surfaces only. They are not canonical authority after raw custody has been established in the evidence repository.
+
+No source-system deletion or account downgrade should be recommended until mirror parity, manifest parity, and cooling-off checks pass.
+
+## Required dashboard states
+
+Exodus Dashboard should expose these states:
+
+- discovered
+- planned
+- landing
+- landed
+- deduped
+- processing
+- validated
+- blocked
+- proof-ready
+- cooling-off
+- deletion-eligible
+
+## Required metrics
+
+- Exit Readiness Index
+- Provider Control Surface score
+- migrated blob count
+- migrated unique bytes
+- duplicate bytes eliminated
+- source aliases preserved
+- blocked objects
+- open-format conversions
+- proof packs generated
+- deletion-eligible source objects
+
+## Boundary
+
+Exodus owns user experience, planning, scoring, and guidance.
+
+The evidence fabric owns raw custody, hash identity, source alias preservation, manifests, parser runs, and validation records.
+
+Semantic projection into SHIR, Knowledge Context, and graph surfaces is later-phase work and must not replace raw custody.

--- a/docs/evidence-fabric-validation.md
+++ b/docs/evidence-fabric-validation.md
@@ -1,0 +1,44 @@
+# Evidence Fabric Contract Validation
+
+## Status
+
+Bootstrap validation runbook.
+
+## Purpose
+
+This document records the validation entrypoints for the Exodus evidence-fabric dashboard, migration, notes, and owned-media contracts.
+
+## Preferred complete validation command
+
+Run from the repository root:
+
+```bash
+python3 scripts/validate_all_evidence_fabric_contracts.py
+```
+
+This runs:
+
+- `scripts/validate_evidence_dashboard_state.py`
+- `scripts/validate_evidence_fabric_dashboard_contracts.py`
+- `scripts/validate_notes_source_profiles.py`
+- `scripts/validate_owned_media_source_profile.py`
+
+## Makefile status
+
+The current `Makefile` target `validate-evidence-fabric-contracts` points at the earlier aggregate validator. A follow-up should update it to call `scripts/validate_all_evidence_fabric_contracts.py` so owned-media validation is included in the default evidence-fabric validation path.
+
+## Expected output
+
+```text
+OK: all Exodus evidence-fabric contract validators passed
+```
+
+## Coverage
+
+The complete validator covers:
+
+- dashboard state,
+- migration wave planning,
+- proof-pack summaries,
+- Google Keep / iCloud Notes / OneNote source profiles,
+- owned music and video source profiles.

--- a/docs/makefile-complete-validation-followup.md
+++ b/docs/makefile-complete-validation-followup.md
@@ -1,0 +1,42 @@
+# Makefile Complete Validation Follow-up
+
+## Status
+
+Follow-up required after the evidence-fabric contract tranche lands.
+
+## Purpose
+
+This branch now contains a complete evidence-fabric validation entrypoint:
+
+```bash
+python3 scripts/validate_complete_evidence_fabric_contracts.py
+```
+
+It includes:
+
+- dashboard state validation,
+- migration wave and proof-pack validation,
+- notes provider validation,
+- owned media source validation,
+- owned media attestation validation.
+
+## Current Makefile state
+
+The current `Makefile` was added earlier in this tranche and points `validate-evidence-fabric-contracts` at the prior aggregate validator.
+
+A follow-up should update that target to call:
+
+```bash
+python3 scripts/validate_complete_evidence_fabric_contracts.py
+```
+
+## Why this is a follow-up
+
+The connector path in this session is reliable for additive files. It does not currently expose a safe high-level overwrite for existing files, and the low-level commit helpers did not expose enough tree metadata in the commit fetch output to justify mutating the existing `Makefile` blindly.
+
+## Desired final target
+
+```make
+validate-evidence-fabric-contracts:
+	python3 scripts/validate_complete_evidence_fabric_contracts.py
+```

--- a/docs/notes-provider-ingest.md
+++ b/docs/notes-provider-ingest.md
@@ -1,0 +1,127 @@
+# Notes Provider Ingest Plan
+
+## Status
+
+Planned Exodus / evidence-fabric integration surface.
+
+## Purpose
+
+This document adds first-class notes migration coverage for Apple/iCloud Notes, Microsoft OneNote, and Google Keep.
+
+Notes are not just small text files. They may include rich text, checklists, embedded images, attachments, links, drawings, audio, OCR-relevant images, collaboration metadata, folders, labels, and provider-specific sync state. Exodus must preserve raw exports first, then normalize into open derived records.
+
+## Provider families
+
+### Apple / iCloud Notes
+
+Apple Notes and iCloud Notes are treated as Apple-provider ingress surfaces.
+
+Expected source paths:
+
+- iCloud Notes web/export capture
+- Apple Notes app export where available
+- local trusted-device collection
+- user-provided archive bundles
+- screenshot or PDF exports for locked or difficult notes
+
+Important metadata:
+
+- folder path
+- note title
+- created and modified times where available
+- attachment references
+- locked-note status if known
+- collaboration/share status if known
+- source account and device context
+
+### Microsoft OneNote
+
+OneNote is treated as a Microsoft-provider ingress surface.
+
+Expected source paths:
+
+- OneNote notebook exports
+- Microsoft Graph or OneDrive-backed notebook metadata later
+- local app export where available
+- PDF/HTML/package exports
+- user-provided notebook archive bundles
+
+Important metadata:
+
+- notebook
+- section
+- page
+- page title
+- page creation and modification times where available
+- embedded files
+- ink/drawing presence
+- audio/transcription presence
+- collaboration/share status if known
+
+### Google Keep
+
+Google Keep is treated as the Google notes equivalent for first-pass Exodus support.
+
+Expected source paths:
+
+- Google Takeout Keep export
+- Keep HTML/JSON export payloads
+- labels
+- archived/pinned/trash state where available
+- image and audio attachments where available
+
+Important metadata:
+
+- note title or synthetic title
+- text body
+- labels
+- color/category if available
+- pinned/archived/trash flags
+- created and modified times where available
+- attachment references
+- source Takeout bundle reference
+
+## Custody rules
+
+1. Raw note exports are preserved as `EvidenceBlob` objects before parsing.
+2. Provider-specific filenames and IDs are source aliases, not canonical identity.
+3. Attachments are separate blobs linked back to the note record.
+4. Rich-text, OCR, transcript, markdown, and plain-text views are derived records.
+5. Locked, unsupported, or partially exported notes become blocked objects, not silent drops.
+6. No provider-side deletion is recommended until proof-pack, mirror parity, and cooling-off gates pass.
+
+## Normalized note object expectations
+
+A normalized note should expose:
+
+- provider
+- source export method
+- source locator
+- title
+- container path
+- note body text or derived text ref
+- attachment blob refs
+- labels/tags/folders
+- created and modified timestamps where available
+- raw evidence refs
+- parser run refs
+- validation refs
+- blocked reason if processing failed
+
+## Dashboard behavior
+
+The Exodus Dashboard should show notes as a distinct migration wave type. Users should be able to see:
+
+- notes discovered
+- notes landed
+- notes deduped
+- notes with attachments
+- notes blocked or partially exported
+- notes converted to open formats
+- notes eligible for source-provider downgrade/deletion after validation
+
+## Boundary
+
+Exodus owns note migration planning, dashboard state, recommendations, and proof-pack summaries.
+
+The evidence fabric owns raw note custody, hash identity, source alias preservation, parser runs, validation, and object-store/Postgres registration.

--- a/docs/owned-media-attestation-validation.md
+++ b/docs/owned-media-attestation-validation.md
@@ -1,0 +1,41 @@
+# Owned Media Attestation Validation
+
+## Status
+
+Bootstrap validation note.
+
+## Purpose
+
+This note defines how Exodus validates owned-media attestation records for private migration and local Linux-ready derivatives.
+
+## Validation intent
+
+The validator should prove that:
+
+1. the attestation record conforms to `packages/contracts/owned-media-attestation-record.schema.json`,
+2. captured private-use attestations permit private use,
+3. captured private-use attestations permit local derivative generation,
+4. external/public use remains gated unless a separate capable scope is recorded,
+5. raw custody and context references are preserved.
+
+## Required fixture
+
+- `examples/owned-media-attestation-record.example.json`
+
+## Expected private migration posture
+
+A normal personal-library record should have:
+
+- `attestationStatus: captured`
+- `attestationScope: personal-use`
+- `privateUseAllowed: true`
+- `localDerivativeAllowed: true`
+- `publicDistributionStatus: separate-clearance-required`
+
+## Why this matters
+
+Exodus should not behave as a media police system for private libraries. The system records that the user attested ownership or authorization, captures supporting evidence and context, and allows private migration and local derivatives. Wider publication or marketplace use remains a separate gate.
+
+## Follow-on
+
+Add an executable validator and include it in the complete evidence-fabric validation command once the connector accepts the file write.

--- a/docs/owned-media-export-conversion-architecture.md
+++ b/docs/owned-media-export-conversion-architecture.md
@@ -1,0 +1,261 @@
+# Owned Media Export and Conversion Architecture
+
+## Status
+
+Planned Exodus / evidence-fabric media pipeline.
+
+## Purpose
+
+Owned media must be a first-class Exodus migration surface. Music, videos, home movies, voice memos, playlists, artwork, sidecars, and metadata often bind users to closed Apple, Google, and Microsoft surfaces as strongly as documents and email.
+
+This document defines the first Linux-ready export and conversion architecture for user-owned media.
+
+## Core posture
+
+1. Preserve raw media first.
+2. Record ownership or authorization attestation before local derivative generation.
+3. Treat source paths, library IDs, provider IDs, playlists, and sidecars as evidence aliases.
+4. Prefer remuxing over transcoding when streams are already Linux-compatible.
+5. Create Linux-ready derivatives only after raw custody and attestation gates.
+6. Preserve conversion commands, tool versions, profiles, output hashes, and failure reasons.
+7. Treat locked, DRM-bound, or non-exportable media as blocked or metadata-only.
+8. Public or marketplace distribution remains separately gated.
+
+## Pipeline
+
+### 1. Source discovery
+
+Discover source libraries and exports:
+
+- local Music/Videos folders,
+- Apple Music/iTunes library files and XML where available,
+- Apple Photos exports for user-created videos,
+- Voice Memos exports,
+- Google Takeout exports,
+- Google Drive media,
+- Google Photos exports,
+- Microsoft OneDrive media,
+- Windows media library exports,
+- USB disks,
+- SD cards,
+- NAS folders,
+- phone/camera exports.
+
+### 2. Raw custody
+
+Every source media object lands as an immutable raw blob before conversion.
+
+Record:
+
+- SHA-256,
+- byte length,
+- original path,
+- source provider or local source,
+- source alias set,
+- file timestamps,
+- provider metadata,
+- sidecar metadata,
+- playlist membership,
+- attestation refs.
+
+### 3. Probe and classify
+
+Use a media probe step to inspect:
+
+- container,
+- audio codec,
+- video codec,
+- subtitle streams,
+- chapters,
+- attachments,
+- duration,
+- bitrate,
+- sample rate,
+- channel layout,
+- resolution,
+- frame rate,
+- color metadata,
+- embedded artwork,
+- metadata tags.
+
+### 4. Decide: copy, remux, transcode, or block
+
+Decision order:
+
+1. If the source is locked or access-controlled beyond authorized export, emit blocked or metadata-only.
+2. If the container is inconvenient but streams are compatible, remux.
+3. If the stream codec is lossless or already suitable, preserve and optionally create portable derivative.
+4. If the stream codec is unsupported or too large for target use, transcode to policy-selected Linux-ready derivative.
+5. If conversion fails, preserve raw and emit blocked conversion status.
+
+## Default target policy
+
+### Audio
+
+#### Archival target
+
+- FLAC for lossless archival when the source is lossless or can be preserved without lossy re-encoding.
+
+#### Portable target
+
+- Opus for efficient open playback derivatives.
+
+#### Compatibility fallback
+
+- MP3 only when required for legacy device compatibility.
+
+### Video
+
+#### Archival container
+
+- Matroska (`.mkv`) as the preferred open archival container.
+
+#### Compatibility container
+
+- MP4 for broad device and browser compatibility when needed.
+
+#### Codec policy
+
+Preferred order depends on source, hardware, and user policy:
+
+1. remux/copy existing streams when compatible,
+2. AV1 for open long-term video derivatives when encoding time is acceptable,
+3. VP9 for open web-compatible derivatives where AV1 is not practical,
+4. H.264 for broad compatibility where open-codec purity is less important than playback reach,
+5. preserve HEVC/H.265 by remux where already present and user policy accepts compatibility limitations.
+
+### Subtitles and chapters
+
+- Preserve embedded subtitle streams where possible.
+- Extract text subtitles to SRT or WebVTT derivatives where appropriate.
+- Preserve chapters and chapter titles as sidecar metadata.
+
+### Metadata and artwork
+
+- Preserve original embedded metadata.
+- Emit JSON sidecar metadata for every derivative.
+- Preserve artwork/thumbnail refs as evidence blobs or sidecars.
+- Use MusicBrainz/Picard-style metadata enrichment only as a derivative enrichment step, not as a replacement for source metadata.
+
+## Conversion profiles
+
+### Profile: `audio-archive-flac`
+
+Use for owned lossless music and high-value audio.
+
+- raw preserved: required
+- output: FLAC
+- metadata sidecar: required
+- artwork preservation: required
+- lossy source handling: do not up-convert to pretend lossless; preserve original and optionally create portable derivative
+
+### Profile: `audio-portable-opus`
+
+Use for portable Linux/mobile playback.
+
+- raw preserved: required
+- output: Opus
+- metadata sidecar: required
+- default use: derivative playback copy
+
+### Profile: `video-archive-mkv`
+
+Use for archival videos and home movies.
+
+- raw preserved: required
+- output container: MKV
+- stream copy preferred when possible
+- subtitles and chapters preserved when possible
+- conversion receipt required
+
+### Profile: `video-compatible-mp4`
+
+Use for broad playback compatibility.
+
+- raw preserved: required
+- output container: MP4
+- codec policy: copy compatible streams first; otherwise transcode according to user policy
+- subtitles may require conversion or sidecar export
+
+## Playlists and libraries
+
+Preserve playlists as first-class migration objects.
+
+Required playlist handling:
+
+- original playlist file or library record preserved as raw evidence,
+- canonical playlist object records ordered entries,
+- each entry links to source alias and canonical blob where known,
+- unresolved entries become blockers,
+- emit Linux-compatible playlist derivatives such as M3U/M3U8 where path mapping is stable,
+- retain provider/library playlist IDs as source aliases.
+
+## Storage budget policy
+
+### Budget class: `custody-only`
+
+- raw preserved,
+- no derivatives unless required for metadata extraction,
+- lowest immediate storage expansion.
+
+### Budget class: `playback-ready`
+
+- raw preserved,
+- one Linux-ready derivative per selected object,
+- balances migration usability and storage growth.
+
+### Budget class: `archive-plus-portable`
+
+- raw preserved,
+- archival derivative where useful,
+- portable derivative where useful,
+- highest storage growth and should be explicit.
+
+## Attestation and distribution gates
+
+Private migration and local Linux playback derivatives require captured ownership/use attestation.
+
+Public distribution, marketplace listing, publishing, resale, or sharing requires a separate distribution clearance gate.
+
+Personal-use attestation is sufficient for private library migration and local derivatives, but not for public distribution.
+
+## Failure and blocked states
+
+Conversion jobs may end in:
+
+- `succeeded`,
+- `remuxed`,
+- `transcoded`,
+- `metadata-only`,
+- `blocked-access-control`,
+- `blocked-unsupported-format`,
+- `blocked-storage-budget`,
+- `failed-tool-error`.
+
+Blocked media must remain visible in Exodus Dashboard with a reason and next action.
+
+## Linux library targets
+
+Initial Linux library targets:
+
+- filesystem library with stable path policy,
+- Jellyfin-style media server library,
+- Kodi-style local library and playlists,
+- MusicBrainz/Picard-compatible tagging workflow,
+- generic M3U/M3U8 playlist export.
+
+## Non-goals
+
+- no DRM bypass,
+- no public distribution clearance from private-use attestation alone,
+- no destructive transcode over raw source,
+- no silent dedupe that erases playlist or source alias evidence,
+- no graph projection as canonical custody.
+
+## Next implementation slices
+
+1. Add `OwnedMediaConversionProfile` contract.
+2. Add conversion profile examples.
+3. Add conversion receipt contract.
+4. Add playlist migration contract.
+5. Add dashboard cards for owned-media landing, conversion, blockers, and proof packs.

--- a/docs/owned-media-ingest.md
+++ b/docs/owned-media-ingest.md
@@ -1,0 +1,168 @@
+# Owned Media Ingest and Linux Playback Plan
+
+## Status
+
+Planned Exodus / evidence-fabric integration surface.
+
+## Purpose
+
+Exodus must support user-owned music and video migration. Without owned media capture, export, metadata preservation, and Linux-ready conversion planning, Exodus will not cover the media libraries that keep many users tied to Apple, Google, and Microsoft ecosystems.
+
+This document defines the first planning surface for owned media migration.
+
+## Scope
+
+Owned media includes user-controlled copies of:
+
+- music files,
+- music library exports,
+- playlists,
+- videos,
+- home movies,
+- downloaded media files,
+- camera-roll videos,
+- voice memos and audio recordings,
+- podcast/audio archives where user-controlled,
+- media metadata and artwork.
+
+## Non-goal: bypassing DRM
+
+Exodus should preserve metadata and exportability evidence for DRM-protected media, but it must not bypass DRM or access controls. DRM-locked assets become blocked or metadata-only records unless the user has an authorized export path.
+
+## Provider and source surfaces
+
+### Apple
+
+Possible source surfaces:
+
+- local Music app library files,
+- iTunes/Music library XML exports where available,
+- Finder/iCloud Drive media files,
+- Photos library exports for user-created videos,
+- Voice Memos exports,
+- user-provided archive folders.
+
+### Google
+
+Possible source surfaces:
+
+- Google Takeout exports,
+- Google Drive media files,
+- Google Photos exports for user-created videos,
+- YouTube/YouTube Music export metadata where user-owned/exportable,
+- user-provided archive folders.
+
+### Microsoft
+
+Possible source surfaces:
+
+- OneDrive media files,
+- Windows media library exports,
+- Xbox/Microsoft media metadata where exportable,
+- user-provided archive folders.
+
+### Local / external storage
+
+Possible source surfaces:
+
+- USB disks,
+- SD cards,
+- local Music/Videos folders,
+- phone/camera exports,
+- NAS exports,
+- existing Linux media directories.
+
+## Custody-first rule
+
+1. Raw source media is preserved as an `EvidenceBlob` before any conversion.
+2. Source paths, library IDs, playlist IDs, provider IDs, and metadata are source aliases and evidence.
+3. Derived Linux-ready files are new derivative records, not replacements for raw custody.
+4. Conversion failures become blocked objects with explicit reasons.
+5. DRM-protected or non-exportable assets remain blocked or metadata-only, not silently dropped.
+
+## Linux-ready target formats
+
+Preferred open or broadly Linux-compatible targets should be selected by media type and quality requirements.
+
+First-pass targets:
+
+- Audio archival: FLAC where lossless preservation is possible.
+- Audio portable/playback: Opus or Ogg Vorbis where conversion is appropriate.
+- Audio compatibility fallback: MP3 only when needed for device compatibility.
+- Video container: Matroska (`.mkv`) for archival/open workflows.
+- Video compatibility container: MP4 where broad playback compatibility is required.
+- Video codecs: AV1, VP9, or H.264 depending on source, hardware support, and user policy.
+- Subtitles: SRT or WebVTT where extractable.
+- Metadata sidecars: JSON and/or MusicBrainz/Picard-compatible metadata where possible.
+
+## Metadata preservation
+
+Exodus should preserve:
+
+- title,
+- artist/creator,
+- album/show/project,
+- track number,
+- disc number,
+- genre,
+- year/date,
+- duration,
+- bitrate,
+- codec,
+- container,
+- sample rate,
+- channels,
+- resolution,
+- frame rate,
+- artwork/thumbnail refs,
+- playlist membership,
+- original path,
+- provider/source ID,
+- library export ID,
+- checksum,
+- conversion profile,
+- conversion command digest.
+
+## Dashboard behavior
+
+Owned media should be a first-class Exodus migration panel.
+
+Users should see:
+
+- media discovered,
+- raw media landed,
+- unique media bytes landed,
+- duplicate media eliminated,
+- playlists preserved,
+- metadata completeness,
+- DRM/blocked assets,
+- conversion queue status,
+- Linux-ready derivatives created,
+- proof packs generated.
+
+## Conversion policy
+
+Conversion should be policy-driven and opt-in per wave.
+
+Default posture:
+
+- preserve raw first,
+- do not destructively transcode,
+- prefer lossless extraction/remuxing before lossy conversion,
+- create derivatives only after raw custody,
+- record conversion tool/version/settings,
+- keep conversion receipts and output hashes.
+
+## Next design questions
+
+The next discussion should decide:
+
+- default audio archival target,
+- default audio portable target,
+- default video archival container,
+- default video compatibility container,
+- when to remux versus transcode,
+- how to handle large video files and storage budgets,
+- how to preserve playlists across providers,
+- how to represent DRM-blocked media without unsafe bypass behavior,
+- how to integrate MusicBrainz/Picard-style metadata enrichment.

--- a/docs/owned-media-ownership-attestation.md
+++ b/docs/owned-media-ownership-attestation.md
@@ -1,0 +1,104 @@
+# Owned Media Ownership Attestation Policy
+
+## Status
+
+Planned Exodus / evidence-fabric policy for user-owned media migration.
+
+## Purpose
+
+Exodus should help users migrate their own media libraries without becoming a media-policing system.
+
+For private migration, backup, indexing, Linux playback, and local library conversion, Exodus should require and preserve an ownership/use attestation plus supporting context. Exodus should not attempt to adjudicate every third-party intellectual-property question for personal imports.
+
+Marketplace, public sharing, resale, redistribution, publishing, or commercial distribution are different surfaces. Those require an explicit distribution-clearance gate and are out of scope for the private migration default.
+
+## Core rule
+
+For owned media ingestion:
+
+1. ask the user to attest that they own, created, purchased, licensed, or are otherwise authorized to migrate the media for personal use,
+2. capture available supporting evidence and context,
+3. preserve raw media first,
+4. record the attestation as evidence,
+5. permit private migration and Linux-ready derivative generation when the attestation gate passes,
+6. block marketplace/public distribution unless a separate distribution-clearance gate passes.
+
+## What Exodus records
+
+The evidence fabric should capture:
+
+- user attestation text,
+- attestation time,
+- attesting user/account reference,
+- media object reference,
+- source profile reference,
+- acquisition run reference,
+- evidence refs such as receipts, library exports, provider metadata, local file paths, sidecars, or device export manifests,
+- source alias refs,
+- conversion-policy refs,
+- distribution clearance status.
+
+## What Exodus does not do by default
+
+Exodus does not:
+
+- bypass DRM,
+- remove access controls,
+- infer redistribution rights from possession,
+- police private libraries beyond recording the attestation gate,
+- delete or alter raw source files,
+- grant marketplace/public distribution clearance by default.
+
+## Private-use default
+
+The default owned-media state is:
+
+- `personal-use-attested`,
+- `private-library-allowed`,
+- `local-conversion-allowed`,
+- `marketplace-distribution-blocked`.
+
+This gives users a practical migration path while keeping distribution-sensitive workflows gated.
+
+## Distribution boundary
+
+Marketplace or public distribution requires a separate policy decision and should not rely only on personal-use attestation.
+
+Distribution clearance may require additional evidence such as:
+
+- explicit license grant,
+- creator/original-work attestation,
+- public-domain or open-license evidence,
+- marketplace-specific rights record,
+- review/approval receipt.
+
+## Compliance posture
+
+The compliance objective is evidence capture, not omniscient enforcement.
+
+Exodus records that:
+
+- the user attested ownership or authorization,
+- available evidence/context was captured,
+- raw custody was preserved,
+- conversion was performed only after the attestation gate,
+- public distribution was blocked unless separately cleared.
+
+## Dashboard behavior
+
+The Exodus Dashboard should show owned media attestation state:
+
+- attestation required,
+- attestation captured,
+- evidence captured,
+- conversion allowed,
+- distribution blocked,
+- distribution clearance required,
+- blocked due to DRM/access control,
+- metadata-only record.
+
+## Relationship to owned media ingest
+
+This policy complements `docs/owned-media-ingest.md`.
+
+Owned-media ingest defines source surfaces, formats, and conversion planning. This document defines the ownership/use attestation gate that controls whether private migration and derivative conversion may proceed.

--- a/docs/playlist-migration.md
+++ b/docs/playlist-migration.md
@@ -1,0 +1,113 @@
+# Playlist Migration Plan
+
+## Status
+
+Planned Exodus / evidence-fabric media migration surface.
+
+## Purpose
+
+Music and video migration is not credible without playlist preservation. Users do not only own files; they own organization, order, context, library structure, and curated collections.
+
+This document defines the first playlist migration plan for Exodus.
+
+## Scope
+
+Playlist migration covers:
+
+- music playlists,
+- video playlists,
+- mixed media playlists,
+- album/project queues,
+- user-created ordered collections,
+- provider/library playlist IDs,
+- playlist membership and ordering,
+- unresolved entries,
+- duplicate entries,
+- source aliases and canonical blob links,
+- Linux-compatible playlist derivatives.
+
+## Provider surfaces
+
+Initial provider/library surfaces include:
+
+- Apple Music / iTunes library playlists,
+- local M3U/M3U8/PLS playlists,
+- Google Takeout media playlist metadata where available,
+- YouTube/YouTube Music export metadata where user-owned/exportable,
+- OneDrive/local Windows media playlists,
+- folder-order derived playlists for user-selected media folders.
+
+## Custody rules
+
+1. Preserve the raw playlist or source library record first.
+2. Preserve provider/library playlist IDs as source aliases.
+3. Preserve original order.
+4. Preserve unresolved entries as blockers, not silent drops.
+5. Resolve entries to canonical media blobs where possible.
+6. Emit Linux-compatible playlist derivatives only after source mapping is recorded.
+7. Never erase duplicate entries unless the user explicitly requests playlist normalization.
+
+## Canonical playlist model
+
+A playlist migration record should capture:
+
+- provider or local source,
+- playlist ID,
+- playlist title,
+- playlist type,
+- source locator,
+- raw evidence ref,
+- ordered entries,
+- per-entry original locator,
+- per-entry canonical blob ref where resolved,
+- per-entry status,
+- output playlist refs,
+- unresolved entry count,
+- duplicate entry count,
+- generated-at timestamp.
+
+## Entry states
+
+Playlist entries may be:
+
+- `resolved`,
+- `missing-source`,
+- `duplicate-preserved`,
+- `blocked-access-control`,
+- `metadata-only`,
+- `unsupported`,
+- `pending`.
+
+## Output derivatives
+
+First-pass Linux-compatible derivatives:
+
+- M3U8 for stable UTF-8 path playlists,
+- M3U where legacy compatibility is required,
+- JSON sidecar with canonical refs and source aliases,
+- CSV only for human review/export, not canonical state.
+
+## Path policy
+
+Playlist derivatives should use stable relative paths where possible.
+
+Absolute source-provider paths should remain evidence aliases, not derivative playback paths.
+
+## Dashboard behavior
+
+Exodus Dashboard should show:
+
+- playlists discovered,
+- playlists landed,
+- entries resolved,
+- entries unresolved,
+- duplicate entries preserved,
+- derivative playlists generated,
+- blockers by provider/source,
+- proof-pack refs.
+
+## Relationship to owned media
+
+Playlist migration depends on owned media raw custody and ownership/use attestation where entries point to media files.
+
+Public distribution remains separately gated. Playlist preservation for a private local library does not imply public distribution rights.

--- a/examples/ai-chat-conversation-document.example.json
+++ b/examples/ai-chat-conversation-document.example.json
@@ -1,0 +1,36 @@
+{
+  "id": "urn:sp:exodus:ai-chat-conversation-document:chatgpt-conversation-001",
+  "kind": "AIChatConversationDocument",
+  "specVersion": "0.1.0",
+  "provider": "openai",
+  "conversationId": "chatgpt-conversation-001",
+  "title": "Evidence fabric planning session",
+  "createdAtUtc": "2026-05-05T15:00:00Z",
+  "updatedAtUtc": "2026-05-05T15:30:00Z",
+  "participantRoles": ["user", "assistant"],
+  "messageCount": 42,
+  "characterCount": 120000,
+  "attachmentRefs": [
+    "urn:sp:evidence:blob:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  ],
+  "rawEvidenceRefs": [
+    "urn:sp:evidence:blob:sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  ],
+  "documentDerivatives": [
+    {
+      "format": "markdown",
+      "ref": "urn:sp:exodus:chat-doc:chatgpt-conversation-001-md"
+    },
+    {
+      "format": "jsonl",
+      "ref": "urn:sp:exodus:chat-doc:chatgpt-conversation-001-jsonl"
+    },
+    {
+      "format": "chunk-manifest",
+      "ref": "urn:sp:exodus:chunk-manifest:chatgpt-conversation-001"
+    }
+  ],
+  "redactionStatus": "review-required",
+  "searchStatus": "queued",
+  "notes": "Conversation imported as a historical document record; model outputs are not treated as verified facts."
+}

--- a/examples/ai-chat-source-profile.chatgpt.example.json
+++ b/examples/ai-chat-source-profile.chatgpt.example.json
@@ -1,0 +1,20 @@
+{
+  "id": "urn:sp:exodus:ai-chat-source-profile:chatgpt",
+  "kind": "AIChatSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "openai",
+  "surface": "chatgpt",
+  "ingestMethods": ["data-export", "archive-folder", "html-export", "json-export"],
+  "expectedArtifacts": [
+    "conversation-history",
+    "message-tree-or-message-list",
+    "attachments-or-generated-files",
+    "shared-link-context-where-available",
+    "account-export-metadata"
+  ],
+  "preserveRawFirst": true,
+  "attachmentsExpected": true,
+  "requiresRedactionReview": true,
+  "notes": "ChatGPT/OpenAI export is treated as an ingress archive for conversation-as-document migration.",
+  "updatedAtUtc": "2026-05-05T15:40:00Z"
+}

--- a/examples/ai-chat-source-profile.claude.example.json
+++ b/examples/ai-chat-source-profile.claude.example.json
@@ -1,0 +1,19 @@
+{
+  "id": "urn:sp:exodus:ai-chat-source-profile:claude",
+  "kind": "AIChatSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "anthropic",
+  "surface": "claude",
+  "ingestMethods": ["data-export", "workspace-export", "archive-folder", "json-export", "markdown-export"],
+  "expectedArtifacts": [
+    "conversation-history",
+    "project-or-workspace-context",
+    "attachments-or-generated-files",
+    "account-export-metadata"
+  ],
+  "preserveRawFirst": true,
+  "attachmentsExpected": true,
+  "requiresRedactionReview": true,
+  "notes": "Claude/Anthropic export is treated as an ingress archive for conversation-as-document migration.",
+  "updatedAtUtc": "2026-05-05T15:41:00Z"
+}

--- a/examples/blocked-object-report.example.json
+++ b/examples/blocked-object-report.example.json
@@ -1,0 +1,24 @@
+{
+  "id": "urn:sp:exodus:blocked-object-report:wave-google-drive-001",
+  "kind": "BlockedObjectReport",
+  "specVersion": "0.1.0",
+  "reportId": "blocked-object-report-google-drive-001",
+  "migrationWaveId": "wave-google-drive-001",
+  "generatedAtUtc": "2026-05-05T17:30:00Z",
+  "blockedObjects": [
+    {
+      "sourceLocator": "gdrive:/Case/LockedMedia.mov",
+      "canonicalBlobRef": "urn:sp:evidence:blob:sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "provider": "google",
+      "surface": "google-drive",
+      "blockerCode": "ACCESS_CONTROL_LIMITED",
+      "severity": "warn",
+      "message": "Object requires metadata-only handling until an authorized export path is available.",
+      "nextAction": "request alternate export or mark metadata-only",
+      "metadataOnly": true
+    }
+  ],
+  "blockedCount": 1,
+  "metadataOnlyCount": 1,
+  "notes": "Blocked object remains visible and proof-pack eligible as metadata-only."
+}

--- a/examples/conversation-reuse-policy.example.json
+++ b/examples/conversation-reuse-policy.example.json
@@ -1,0 +1,14 @@
+{
+  "id": "urn:sp:exodus:conversation-reuse-policy:chatgpt-conversation-001",
+  "kind": "ConversationReusePolicy",
+  "specVersion": "0.1.0",
+  "sourceConversationRef": "urn:sp:exodus:ai-chat-conversation-document:chatgpt-conversation-001",
+  "reuseMode": "citation-source",
+  "redactionRequired": true,
+  "citationRequired": true,
+  "treatModelOutputsAsHistorical": true,
+  "allowedTargets": ["exodus-dashboard", "sourceos-chat", "workspace-search", "knowledge-context"],
+  "blockedReasons": [],
+  "notes": "Imported chat may be cited as historical context after redaction review. Assistant outputs are not treated as verified facts.",
+  "updatedAtUtc": "2026-05-05T16:25:00Z"
+}

--- a/examples/conversion-receipt.example.json
+++ b/examples/conversion-receipt.example.json
@@ -1,0 +1,24 @@
+{
+  "id": "urn:sp:exodus:conversion-receipt:audio-opus-001",
+  "kind": "ConversionReceipt",
+  "specVersion": "0.1.0",
+  "receiptId": "audio-opus-001",
+  "migrationWaveId": "wave-owned-media-001",
+  "sourceBlobRef": "urn:sp:evidence:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "outputBlobRef": "urn:sp:evidence:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "profileRef": "urn:sp:exodus:owned-media-conversion-profile:audio-portable-opus",
+  "action": "transcode",
+  "status": "succeeded",
+  "tool": {
+    "name": "ffmpeg",
+    "version": "policy-pinned",
+    "configDigest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "inputDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "outputDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "metadataSidecarRef": "urn:sp:exodus:media-sidecar:audio-opus-001-json",
+  "rawCustodyPreserved": true,
+  "attestationRef": "urn:sp:exodus:owned-media-attestation:local-track-001",
+  "notes": "Raw source preserved; portable playback derivative generated after attestation.",
+  "generatedAtUtc": "2026-05-05T18:10:00Z"
+}

--- a/examples/deletion-eligibility-record.example.json
+++ b/examples/deletion-eligibility-record.example.json
@@ -1,0 +1,28 @@
+{
+  "id": "urn:sp:exodus:deletion-eligibility:wave-google-drive-001",
+  "kind": "DeletionEligibilityRecord",
+  "specVersion": "0.1.0",
+  "recordId": "deletion-eligibility-google-drive-001",
+  "provider": "google",
+  "migrationWaveId": "wave-google-drive-001",
+  "sourceSurface": "google-drive",
+  "eligibilityStatus": "cooling-off",
+  "evaluatedAtUtc": "2026-05-05T18:40:00Z",
+  "checks": {
+    "rawCustodyComplete": true,
+    "sourceAliasesPreserved": true,
+    "mirrorParityPassed": true,
+    "manifestParityPassed": true,
+    "blockedObjectsResolved": true,
+    "redactionReviewComplete": true,
+    "proofPackGenerated": true,
+    "coolingOffComplete": false
+  },
+  "proofPackRef": "urn:sp:exodus:proof-pack-summary:proof-pack-google-drive-001",
+  "sourceAliasReportRef": "urn:sp:exodus:source-alias-report:wave-google-drive-001",
+  "blockedObjectReportRef": "urn:sp:exodus:blocked-object-report:wave-google-drive-001",
+  "redactionReviewRef": "urn:sp:exodus:redaction-review:chatgpt-conversation-001",
+  "coolingOffEndsAtUtc": "2026-06-04T18:40:00Z",
+  "decisionReason": "All proof checks passed, but cooling-off window is still active.",
+  "nextAction": "Wait for cooling-off completion before marking source objects deletion-eligible."
+}

--- a/examples/evidence-dashboard-state.example.json
+++ b/examples/evidence-dashboard-state.example.json
@@ -1,0 +1,37 @@
+{
+  "id": "urn:sp:exodus:evidence-dashboard-state:wave-google-drive-001",
+  "kind": "EvidenceDashboardState",
+  "specVersion": "0.1.0",
+  "provider": "google-drive",
+  "migrationWaveId": "wave-google-drive-001",
+  "state": "landed",
+  "metrics": {
+    "exitReadinessIndex": 42,
+    "providerControlSurfaceScore": 77,
+    "migratedBlobCount": 1200,
+    "migratedUniqueBytes": 918273645,
+    "duplicateBytesEliminated": 104857600,
+    "sourceAliasesPreserved": 1340,
+    "blockedObjects": 12,
+    "openFormatConversions": 88,
+    "proofPacksGenerated": 1,
+    "deletionEligibleSourceObjects": 0
+  },
+  "evidenceRefs": [
+    "urn:sp:evidence:acquisition:RUN0001",
+    "urn:sp:evidence:validation:VALID0001"
+  ],
+  "blockers": [
+    {
+      "code": "MIRROR_PARITY_PENDING",
+      "message": "Mirror parity has not completed for this migration wave.",
+      "severity": "warn"
+    }
+  ],
+  "nextActions": [
+    "complete mirror parity check",
+    "generate source alias report",
+    "start cooling-off window after validation passes"
+  ],
+  "updatedAtUtc": "2026-05-05T02:10:00Z"
+}

--- a/examples/migration-wave-plan.example.json
+++ b/examples/migration-wave-plan.example.json
@@ -1,0 +1,27 @@
+{
+  "id": "urn:sp:exodus:migration-wave:wave-google-drive-001",
+  "kind": "MigrationWavePlan",
+  "specVersion": "0.1.0",
+  "provider": "google-drive",
+  "waveId": "wave-google-drive-001",
+  "scope": {
+    "sourceType": "google-drive",
+    "selection": "folder:case-001",
+    "estimatedObjectCount": 1500,
+    "estimatedBytes": 1073741824
+  },
+  "target": {
+    "objectStore": "seaweedfs-s3",
+    "metadataStore": "postgres",
+    "landingPrefix": "raw/sha256"
+  },
+  "policy": {
+    "deleteSourceAfterIngest": false,
+    "requiresMirrorParity": true,
+    "requiresManifestParity": true,
+    "requiresCoolingOff": true,
+    "coolingOffDays": 30
+  },
+  "parserRoutes": ["document", "text-log", "metadata"],
+  "createdAtUtc": "2026-05-05T05:00:00Z"
+}

--- a/examples/notes-source-profile.example.json
+++ b/examples/notes-source-profile.example.json
@@ -1,0 +1,23 @@
+{
+  "id": "urn:sp:exodus:notes-source-profile:google-keep",
+  "kind": "NotesSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "google",
+  "surface": "google-keep",
+  "ingestMethods": ["takeout-export", "html-export", "json-export"],
+  "expectedMetadata": [
+    "title",
+    "body-text",
+    "labels",
+    "pinned-state",
+    "archived-state",
+    "attachment-refs",
+    "created-time",
+    "modified-time"
+  ],
+  "attachmentSupport": true,
+  "collaborationMetadata": false,
+  "preserveRawFirst": true,
+  "notes": "Google Keep is the first-pass Google notes equivalent for Exodus support.",
+  "updatedAtUtc": "2026-05-05T05:25:00Z"
+}

--- a/examples/notes-source-profile.icloud-notes.example.json
+++ b/examples/notes-source-profile.icloud-notes.example.json
@@ -1,0 +1,23 @@
+{
+  "id": "urn:sp:exodus:notes-source-profile:icloud-notes",
+  "kind": "NotesSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "apple",
+  "surface": "icloud-notes",
+  "ingestMethods": ["web-export", "trusted-device-collector", "archive-bundle", "pdf-export", "screenshot-capture"],
+  "expectedMetadata": [
+    "folder-path",
+    "title",
+    "body-text",
+    "attachment-refs",
+    "locked-status",
+    "share-status",
+    "created-time",
+    "modified-time"
+  ],
+  "attachmentSupport": true,
+  "collaborationMetadata": true,
+  "preserveRawFirst": true,
+  "notes": "Apple Notes and iCloud Notes are treated as Apple ingress surfaces only.",
+  "updatedAtUtc": "2026-05-05T05:30:00Z"
+}

--- a/examples/notes-source-profile.onenote.example.json
+++ b/examples/notes-source-profile.onenote.example.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:sp:exodus:notes-source-profile:onenote",
+  "kind": "NotesSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "microsoft",
+  "surface": "onenote",
+  "ingestMethods": ["web-export", "api-collector", "local-app-export", "archive-bundle", "pdf-export", "html-export"],
+  "expectedMetadata": [
+    "notebook",
+    "section",
+    "page",
+    "page-title",
+    "attachment-refs",
+    "ink-or-drawing-presence",
+    "audio-or-transcript-presence",
+    "share-status",
+    "created-time",
+    "modified-time"
+  ],
+  "attachmentSupport": true,
+  "collaborationMetadata": true,
+  "preserveRawFirst": true,
+  "notes": "OneNote is treated as a Microsoft ingress surface only.",
+  "updatedAtUtc": "2026-05-05T05:35:00Z"
+}

--- a/examples/owned-media-attestation-record.example.json
+++ b/examples/owned-media-attestation-record.example.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:sp:exodus:owned-media-attestation:local-track-001",
+  "kind": "OwnedMediaAttestationRecord",
+  "specVersion": "0.1.0",
+  "mediaRef": "urn:sp:evidence:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sourceProfileRef": "urn:sp:exodus:owned-media-source-profile:local-music-video",
+  "acquisitionRunRef": "urn:sp:evidence:acquisition:RUN0001",
+  "attestingSubjectRef": "urn:sp:subject:user-local-owner",
+  "attestationScope": "personal-use",
+  "attestationStatus": "captured",
+  "evidenceRefs": [
+    "urn:sp:evidence:source-alias:local-music-folder",
+    "urn:sp:evidence:metadata:library-export-001"
+  ],
+  "contextRefs": [
+    "urn:sp:exodus:migration-wave:wave-owned-media-001"
+  ],
+  "privateUseAllowed": true,
+  "localDerivativeAllowed": true,
+  "publicDistributionStatus": "separate-clearance-required",
+  "accessControlStatus": "none-observed",
+  "attestationTextDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "notes": "User attested personal ownership or authorization for private migration and local Linux playback derivatives. Public distribution remains separately gated.",
+  "attestedAtUtc": "2026-05-05T13:20:00Z"
+}

--- a/examples/owned-media-conversion-profile.audio-archive-flac.example.json
+++ b/examples/owned-media-conversion-profile.audio-archive-flac.example.json
@@ -1,0 +1,18 @@
+{
+  "id": "urn:sp:exodus:owned-media-conversion-profile:audio-archive-flac",
+  "kind": "OwnedMediaConversionProfile",
+  "specVersion": "0.1.0",
+  "profileName": "audio-archive-flac",
+  "mediaKind": "audio",
+  "rawCustodyRequired": true,
+  "attestationRequired": true,
+  "distributionClearanceRequired": false,
+  "preferredAction": "transcode",
+  "targetContainer": "flac",
+  "targetCodec": "flac",
+  "metadataSidecar": "json",
+  "budgetClass": "archive-plus-portable",
+  "failureStates": ["metadata-only", "blocked-access-control", "failed-tool-error"],
+  "notes": "Use for lossless or high-value audio. Do not up-convert lossy sources to pretend lossless custody.",
+  "updatedAtUtc": "2026-05-05T13:45:00Z"
+}

--- a/examples/owned-media-conversion-profile.audio-portable-opus.example.json
+++ b/examples/owned-media-conversion-profile.audio-portable-opus.example.json
@@ -1,0 +1,18 @@
+{
+  "id": "urn:sp:exodus:owned-media-conversion-profile:audio-portable-opus",
+  "kind": "OwnedMediaConversionProfile",
+  "specVersion": "0.1.0",
+  "profileName": "audio-portable-opus",
+  "mediaKind": "audio",
+  "rawCustodyRequired": true,
+  "attestationRequired": true,
+  "distributionClearanceRequired": false,
+  "preferredAction": "transcode",
+  "targetContainer": "ogg",
+  "targetCodec": "opus",
+  "metadataSidecar": "json",
+  "budgetClass": "playback-ready",
+  "failureStates": ["metadata-only", "blocked-access-control", "failed-tool-error"],
+  "notes": "Use for efficient portable local playback derivatives after raw custody and attestation.",
+  "updatedAtUtc": "2026-05-05T13:46:00Z"
+}

--- a/examples/owned-media-conversion-profile.video-archive-mkv.example.json
+++ b/examples/owned-media-conversion-profile.video-archive-mkv.example.json
@@ -1,0 +1,18 @@
+{
+  "id": "urn:sp:exodus:owned-media-conversion-profile:video-archive-mkv",
+  "kind": "OwnedMediaConversionProfile",
+  "specVersion": "0.1.0",
+  "profileName": "video-archive-mkv",
+  "mediaKind": "video",
+  "rawCustodyRequired": true,
+  "attestationRequired": true,
+  "distributionClearanceRequired": false,
+  "preferredAction": "remux",
+  "targetContainer": "mkv",
+  "metadataSidecar": "json",
+  "subtitleTarget": "srt-or-webvtt",
+  "budgetClass": "archive-plus-portable",
+  "failureStates": ["metadata-only", "blocked-access-control", "blocked-unsupported-format", "blocked-storage-budget", "failed-tool-error"],
+  "notes": "Use for archival video derivatives. Prefer stream copy/remux before transcode.",
+  "updatedAtUtc": "2026-05-05T13:47:00Z"
+}

--- a/examples/owned-media-conversion-profile.video-compatible-mp4.example.json
+++ b/examples/owned-media-conversion-profile.video-compatible-mp4.example.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schemas.socioprophet.ai/exodus/0.1.0/owned-media-conversion-profile.schema.json",
+  "id": "urn:sp:exodus:owned-media-conversion-profile:video-compatible-mp4",
+  "kind": "OwnedMediaConversionProfile",
+  "specVersion": "0.1.0",
+  "profileName": "video-compatible-mp4",
+  "mediaKind": "video",
+  "rawCustodyRequired": true,
+  "attestationRequired": true,
+  "distributionClearanceRequired": false,
+  "preferredAction": "remux",
+  "targetContainer": "mp4",
+  "targetCodec": "copy-compatible-or-policy-selected",
+  "metadataSidecar": "json",
+  "subtitleTarget": "srt-or-webvtt",
+  "budgetClass": "playback-ready",
+  "failureStates": ["metadata-only", "blocked-access-control", "blocked-unsupported-format", "blocked-storage-budget", "failed-tool-error"],
+  "notes": "Use for broad playback compatibility. Copy compatible streams first; transcode only when policy requires it.",
+  "updatedAtUtc": "2026-05-05T13:48:00Z"
+}

--- a/examples/owned-media-source-profile.example.json
+++ b/examples/owned-media-source-profile.example.json
@@ -1,0 +1,37 @@
+{
+  "id": "urn:sp:exodus:owned-media-source-profile:local-music-video",
+  "kind": "OwnedMediaSourceProfile",
+  "specVersion": "0.1.0",
+  "provider": "local",
+  "surface": "local-music-video-library",
+  "mediaKinds": ["music", "video", "playlist", "voice-memo", "home-movie"],
+  "ingestMethods": ["local-library", "external-disk", "archive-folder", "device-export"],
+  "preferredTargets": {
+    "audioArchival": "flac",
+    "audioPortable": "opus",
+    "videoArchivalContainer": "mkv",
+    "videoCompatibilityContainer": "mp4",
+    "metadataSidecar": "json"
+  },
+  "expectedMetadata": [
+    "title",
+    "artist-or-creator",
+    "album-or-project",
+    "duration",
+    "codec",
+    "container",
+    "bitrate",
+    "sample-rate",
+    "resolution",
+    "frame-rate",
+    "artwork-ref",
+    "playlist-membership",
+    "original-path",
+    "checksum",
+    "conversion-profile"
+  ],
+  "preserveRawFirst": true,
+  "drmPolicy": "blocked-or-metadata-only",
+  "notes": "Owned media is preserved raw before optional Linux-ready derivative conversion.",
+  "updatedAtUtc": "2026-05-05T12:30:00Z"
+}

--- a/examples/playlist-migration-record.example.json
+++ b/examples/playlist-migration-record.example.json
@@ -1,0 +1,36 @@
+{
+  "id": "urn:sp:exodus:playlist-migration:local-favorites-001",
+  "kind": "PlaylistMigrationRecord",
+  "specVersion": "0.1.0",
+  "provider": "local",
+  "playlistId": "local-favorites-001",
+  "title": "Local Favorites",
+  "playlistType": "music",
+  "sourceLocator": "file:///Music/Playlists/Favorites.m3u8",
+  "rawEvidenceRef": "urn:sp:evidence:blob:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "entries": [
+    {
+      "position": 0,
+      "entryStatus": "resolved",
+      "originalLocator": "file:///Music/Track01.flac",
+      "canonicalBlobRef": "urn:sp:evidence:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "title": "Track 01",
+      "artistOrCreator": "Local Artist",
+      "durationSeconds": 180
+    },
+    {
+      "position": 1,
+      "entryStatus": "missing-source",
+      "originalLocator": "file:///Music/MissingTrack.flac",
+      "title": "Missing Track"
+    }
+  ],
+  "outputPlaylistRefs": [
+    "urn:sp:exodus:playlist-output:local-favorites-001-m3u8"
+  ],
+  "unresolvedEntryCount": 1,
+  "duplicateEntryCount": 0,
+  "proofPackRef": "urn:sp:exodus:proof-pack-summary:proof-pack-owned-media-001",
+  "notes": "Original order preserved; unresolved entry retained as blocker.",
+  "generatedAtUtc": "2026-05-05T14:55:00Z"
+}

--- a/examples/proof-pack-summary.example.json
+++ b/examples/proof-pack-summary.example.json
@@ -1,0 +1,22 @@
+{
+  "id": "urn:sp:exodus:proof-pack-summary:proof-pack-google-drive-001",
+  "kind": "ProofPackSummary",
+  "specVersion": "0.1.0",
+  "proofPackId": "proof-pack-google-drive-001",
+  "migrationWaveId": "wave-google-drive-001",
+  "status": "validated",
+  "generatedAtUtc": "2026-05-05T05:15:00Z",
+  "contents": {
+    "manifestRefs": ["urn:sp:evidence:manifest:MANIFEST0001"],
+    "validationRefs": ["urn:sp:evidence:validation:VALID0001"],
+    "sourceAliasReport": "urn:sp:exodus:report:source-aliases-google-drive-001",
+    "mirrorParityReport": "urn:sp:exodus:report:mirror-parity-google-drive-001",
+    "blockedObjectReport": "urn:sp:exodus:report:blocked-objects-google-drive-001",
+    "openFormatConversionReport": "urn:sp:exodus:report:open-format-conversions-google-drive-001"
+  },
+  "eligibility": {
+    "sourceDeletionEligible": false,
+    "providerDowngradeEligible": false,
+    "reason": "Cooling-off period has not completed."
+  }
+}

--- a/examples/provider-downgrade-plan.example.json
+++ b/examples/provider-downgrade-plan.example.json
@@ -1,0 +1,42 @@
+{
+  "id": "urn:sp:exodus:provider-downgrade-plan:google-personal-001",
+  "kind": "ProviderDowngradePlan",
+  "specVersion": "0.1.0",
+  "planId": "google-personal-001",
+  "provider": "google",
+  "currentState": "paid-storage-plan-active",
+  "targetState": "minimal-account-retained-with-canonical-data-offloaded",
+  "planStatus": "ready",
+  "createdAtUtc": "2026-05-05T18:45:00Z",
+  "eligibilityRefs": [
+    "urn:sp:exodus:deletion-eligibility:wave-google-drive-001"
+  ],
+  "proofPackRefs": [
+    "urn:sp:exodus:proof-pack-summary:proof-pack-google-drive-001"
+  ],
+  "riskSummary": {
+    "dataLossRisk": "low",
+    "accountLockoutRisk": "medium",
+    "workflowBreakageRisk": "medium"
+  },
+  "steps": [
+    {
+      "stepId": "verify-proof-pack",
+      "description": "Verify proof pack, source alias report, blocked object report, and deletion eligibility record before provider downgrade.",
+      "status": "ready",
+      "evidenceRef": "urn:sp:exodus:proof-pack-summary:proof-pack-google-drive-001"
+    },
+    {
+      "stepId": "complete-cooling-off",
+      "description": "Wait for cooling-off window to complete before removing or downgrading provider storage commitments.",
+      "status": "pending",
+      "evidenceRef": "urn:sp:exodus:deletion-eligibility:wave-google-drive-001"
+    },
+    {
+      "stepId": "downgrade-storage-plan",
+      "description": "Downgrade provider storage only after all eligibility checks pass and user confirms the action.",
+      "status": "pending"
+    }
+  ],
+  "notes": "Provider downgrade is a guided user action. Exodus supplies proof and risk context but does not automatically delete or downgrade external accounts."
+}

--- a/examples/provider-topology-snapshot.example.json
+++ b/examples/provider-topology-snapshot.example.json
@@ -1,0 +1,39 @@
+{
+  "id": "urn:sp:exodus:provider-topology-snapshot:google-001",
+  "kind": "ProviderTopologySnapshot",
+  "specVersion": "0.1.0",
+  "provider": "google",
+  "snapshotId": "google-001",
+  "discoveredAtUtc": "2026-05-05T17:20:00Z",
+  "accounts": [
+    {
+      "accountRef": "urn:sp:exodus:account:google-primary",
+      "accountType": "personal",
+      "status": "active"
+    }
+  ],
+  "surfaces": [
+    {
+      "surfaceId": "google-drive",
+      "surfaceType": "cloud-drive",
+      "objectEstimate": 1500,
+      "byteEstimate": 1073741824,
+      "discoveryStatus": "discovered"
+    },
+    {
+      "surfaceId": "google-keep",
+      "surfaceType": "notes",
+      "objectEstimate": 240,
+      "byteEstimate": 10485760,
+      "discoveryStatus": "partial",
+      "blockerRefs": ["urn:sp:exodus:blocker:takeout-refresh-needed"]
+    }
+  ],
+  "exportMethods": ["takeout-export", "rclone-drive"],
+  "confidence": {
+    "score": 0.76,
+    "gaps": ["Google Photos estimate pending", "Keep attachment inventory partial"]
+  },
+  "evidenceRefs": ["urn:sp:evidence:acquisition:RUN0001"],
+  "notes": "Initial provider topology snapshot for Google exit planning."
+}

--- a/examples/redaction-review-record.example.json
+++ b/examples/redaction-review-record.example.json
@@ -1,0 +1,20 @@
+{
+  "id": "urn:sp:exodus:redaction-review:chatgpt-conversation-001",
+  "kind": "RedactionReviewRecord",
+  "specVersion": "0.1.0",
+  "reviewId": "chatgpt-conversation-001-redaction-review",
+  "targetRef": "urn:sp:exodus:ai-chat-conversation-document:chatgpt-conversation-001",
+  "reviewStatus": "review-required",
+  "reviewedAtUtc": "2026-05-05T18:15:00Z",
+  "findings": [
+    {
+      "findingType": "personal-data",
+      "severity": "warn",
+      "fieldRef": "messages[*].content",
+      "message": "Conversation may contain personal context and should be reviewed before export."
+    }
+  ],
+  "rawPreserved": true,
+  "exportAllowed": false,
+  "notes": "Raw conversation remains private until redaction review is complete."
+}

--- a/examples/source-alias-report.example.json
+++ b/examples/source-alias-report.example.json
@@ -1,0 +1,30 @@
+{
+  "id": "urn:sp:exodus:source-alias-report:wave-google-drive-001",
+  "kind": "SourceAliasReport",
+  "specVersion": "0.1.0",
+  "reportId": "source-alias-report-google-drive-001",
+  "migrationWaveId": "wave-google-drive-001",
+  "generatedAtUtc": "2026-05-05T17:25:00Z",
+  "aliases": [
+    {
+      "aliasType": "path",
+      "sourceLocator": "gdrive:/Case/File.txt",
+      "canonicalBlobRef": "urn:sp:evidence:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "provider": "google",
+      "surface": "google-drive",
+      "observedAtUtc": "2026-05-05T17:21:00Z"
+    },
+    {
+      "aliasType": "provider-id",
+      "sourceLocator": "gdrive:fileId=abc123",
+      "canonicalBlobRef": "urn:sp:evidence:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "provider": "google",
+      "surface": "google-drive",
+      "observedAtUtc": "2026-05-05T17:21:00Z"
+    }
+  ],
+  "uniqueBlobCount": 1,
+  "aliasCount": 2,
+  "duplicateAliasCount": 1,
+  "notes": "Two source aliases resolve to one canonical blob."
+}

--- a/packages/contracts/ai-chat-conversation-document.schema.json
+++ b/packages/contracts/ai-chat-conversation-document.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/ai-chat-conversation-document.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "conversationId",
+    "title",
+    "messageCount",
+    "rawEvidenceRefs",
+    "documentDerivatives",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "AIChatConversationDocument" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "conversationId": { "type": "string" },
+    "title": { "type": "string" },
+    "createdAtUtc": { "type": "string", "format": "date-time" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" },
+    "participantRoles": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "messageCount": { "type": "integer", "minimum": 0 },
+    "characterCount": { "type": "integer", "minimum": 0 },
+    "attachmentRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "rawEvidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "documentDerivatives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["format", "ref"],
+        "properties": {
+          "format": { "type": "string", "enum": ["markdown", "json", "jsonl", "html", "pdf", "chunk-manifest"] },
+          "ref": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "redactionStatus": {
+      "type": "string",
+      "enum": ["raw-private", "redacted", "review-required", "safe-for-export", "blocked"]
+    },
+    "searchStatus": {
+      "type": "string",
+      "enum": ["not-indexed", "queued", "indexed", "blocked"]
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/ai-chat-source-profile.schema.json
+++ b/packages/contracts/ai-chat-source-profile.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/ai-chat-source-profile.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "surface",
+    "ingestMethods",
+    "preserveRawFirst",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "AIChatSourceProfile" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string", "enum": ["openai", "anthropic", "google", "microsoft", "local", "other"] },
+    "surface": { "type": "string", "enum": ["chatgpt", "claude", "gemini", "copilot", "local-assistant", "other"] },
+    "ingestMethods": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["data-export", "workspace-export", "archive-folder", "html-export", "json-export", "jsonl-export", "markdown-export", "manual-import"] },
+      "minItems": 1
+    },
+    "expectedArtifacts": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "preserveRawFirst": { "type": "boolean" },
+    "attachmentsExpected": { "type": "boolean" },
+    "requiresRedactionReview": { "type": "boolean" },
+    "notes": { "type": "string" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/blocked-object-report.schema.json
+++ b/packages/contracts/blocked-object-report.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/blocked-object-report.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "reportId",
+    "migrationWaveId",
+    "generatedAtUtc",
+    "blockedObjects"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "BlockedObjectReport" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "reportId": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "generatedAtUtc": { "type": "string", "format": "date-time" },
+    "blockedObjects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["sourceLocator", "blockerCode", "severity"],
+        "properties": {
+          "sourceLocator": { "type": "string" },
+          "canonicalBlobRef": { "type": "string" },
+          "provider": { "type": "string" },
+          "surface": { "type": "string" },
+          "blockerCode": { "type": "string" },
+          "severity": { "type": "string", "enum": ["info", "warn", "error"] },
+          "message": { "type": "string" },
+          "nextAction": { "type": "string" },
+          "metadataOnly": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "blockedCount": { "type": "integer", "minimum": 0 },
+    "metadataOnlyCount": { "type": "integer", "minimum": 0 },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/conversation-reuse-policy.schema.json
+++ b/packages/contracts/conversation-reuse-policy.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/conversation-reuse-policy.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "sourceConversationRef",
+    "reuseMode",
+    "redactionRequired",
+    "citationRequired",
+    "treatModelOutputsAsHistorical",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "ConversationReusePolicy" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "sourceConversationRef": { "type": "string" },
+    "reuseMode": {
+      "type": "string",
+      "enum": ["read-only-document", "citation-source", "retrieval-context", "memory-candidate", "blocked"]
+    },
+    "redactionRequired": { "type": "boolean" },
+    "citationRequired": { "type": "boolean" },
+    "treatModelOutputsAsHistorical": { "type": "boolean" },
+    "allowedTargets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["exodus-dashboard", "sourceos-chat", "workspace-search", "knowledge-context", "proof-pack", "none"]
+      }
+    },
+    "blockedReasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": "string" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/conversion-receipt.schema.json
+++ b/packages/contracts/conversion-receipt.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/conversion-receipt.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "receiptId",
+    "migrationWaveId",
+    "sourceBlobRef",
+    "profileRef",
+    "action",
+    "status",
+    "rawCustodyPreserved",
+    "generatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "ConversionReceipt" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "receiptId": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "sourceBlobRef": { "type": "string" },
+    "outputBlobRef": { "type": "string" },
+    "profileRef": { "type": "string" },
+    "action": { "type": "string", "enum": ["copy", "remux", "transcode", "metadata-only", "block"] },
+    "status": { "type": "string", "enum": ["succeeded", "blocked", "failed", "skipped"] },
+    "tool": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "configDigest": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "inputDigest": { "type": "string" },
+    "outputDigest": { "type": "string" },
+    "metadataSidecarRef": { "type": "string" },
+    "failureCode": { "type": "string" },
+    "failureMessage": { "type": "string" },
+    "rawCustodyPreserved": { "type": "boolean" },
+    "attestationRef": { "type": "string" },
+    "notes": { "type": "string" },
+    "generatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/deletion-eligibility-record.schema.json
+++ b/packages/contracts/deletion-eligibility-record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/deletion-eligibility-record.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "recordId",
+    "provider",
+    "migrationWaveId",
+    "eligibilityStatus",
+    "evaluatedAtUtc",
+    "checks"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "DeletionEligibilityRecord" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "recordId": { "type": "string" },
+    "provider": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "sourceSurface": { "type": "string" },
+    "eligibilityStatus": {
+      "type": "string",
+      "enum": ["eligible", "not-eligible", "cooling-off", "blocked", "unknown"]
+    },
+    "evaluatedAtUtc": { "type": "string", "format": "date-time" },
+    "checks": {
+      "type": "object",
+      "required": [
+        "rawCustodyComplete",
+        "sourceAliasesPreserved",
+        "mirrorParityPassed",
+        "manifestParityPassed",
+        "blockedObjectsResolved",
+        "redactionReviewComplete",
+        "proofPackGenerated",
+        "coolingOffComplete"
+      ],
+      "properties": {
+        "rawCustodyComplete": { "type": "boolean" },
+        "sourceAliasesPreserved": { "type": "boolean" },
+        "mirrorParityPassed": { "type": "boolean" },
+        "manifestParityPassed": { "type": "boolean" },
+        "blockedObjectsResolved": { "type": "boolean" },
+        "redactionReviewComplete": { "type": "boolean" },
+        "proofPackGenerated": { "type": "boolean" },
+        "coolingOffComplete": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "proofPackRef": { "type": "string" },
+    "sourceAliasReportRef": { "type": "string" },
+    "blockedObjectReportRef": { "type": "string" },
+    "redactionReviewRef": { "type": "string" },
+    "coolingOffEndsAtUtc": { "type": "string", "format": "date-time" },
+    "decisionReason": { "type": "string" },
+    "nextAction": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/evidence-dashboard-state.schema.json
+++ b/packages/contracts/evidence-dashboard-state.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/evidence-dashboard-state.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "migrationWaveId",
+    "state",
+    "metrics",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "EvidenceDashboardState" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "state": {
+      "type": "string",
+      "enum": [
+        "discovered",
+        "planned",
+        "landing",
+        "landed",
+        "deduped",
+        "processing",
+        "validated",
+        "blocked",
+        "proof-ready",
+        "cooling-off",
+        "deletion-eligible"
+      ]
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "migratedBlobCount",
+        "migratedUniqueBytes",
+        "duplicateBytesEliminated",
+        "sourceAliasesPreserved",
+        "blockedObjects",
+        "proofPacksGenerated"
+      ],
+      "properties": {
+        "exitReadinessIndex": { "type": "number", "minimum": 0, "maximum": 100 },
+        "providerControlSurfaceScore": { "type": "number", "minimum": 0, "maximum": 100 },
+        "migratedBlobCount": { "type": "integer", "minimum": 0 },
+        "migratedUniqueBytes": { "type": "integer", "minimum": 0 },
+        "duplicateBytesEliminated": { "type": "integer", "minimum": 0 },
+        "sourceAliasesPreserved": { "type": "integer", "minimum": 0 },
+        "blockedObjects": { "type": "integer", "minimum": 0 },
+        "openFormatConversions": { "type": "integer", "minimum": 0 },
+        "proofPacksGenerated": { "type": "integer", "minimum": 0 },
+        "deletionEligibleSourceObjects": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["code", "message", "severity"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "severity": { "type": "string", "enum": ["info", "warn", "error"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "nextActions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/migration-wave-plan.schema.json
+++ b/packages/contracts/migration-wave-plan.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/migration-wave-plan.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "waveId",
+    "scope",
+    "target",
+    "policy",
+    "createdAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "MigrationWavePlan" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "waveId": { "type": "string" },
+    "scope": {
+      "type": "object",
+      "required": ["sourceType", "selection", "estimatedObjectCount", "estimatedBytes"],
+      "properties": {
+        "sourceType": {
+          "type": "string",
+          "enum": ["local-files", "google-drive", "icloud-drive", "email", "notes", "mobile-export", "browser-export", "terminal-capture", "office-documents", "other"]
+        },
+        "selection": { "type": "string" },
+        "estimatedObjectCount": { "type": "integer", "minimum": 0 },
+        "estimatedBytes": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "target": {
+      "type": "object",
+      "required": ["objectStore", "metadataStore", "landingPrefix"],
+      "properties": {
+        "objectStore": { "type": "string" },
+        "metadataStore": { "type": "string" },
+        "landingPrefix": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": ["deleteSourceAfterIngest", "requiresMirrorParity", "requiresCoolingOff"],
+      "properties": {
+        "deleteSourceAfterIngest": { "type": "boolean" },
+        "requiresMirrorParity": { "type": "boolean" },
+        "requiresManifestParity": { "type": "boolean" },
+        "requiresCoolingOff": { "type": "boolean" },
+        "coolingOffDays": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "parserRoutes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "blockedReason": { "type": "string" },
+    "createdAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/notes-source-profile.schema.json
+++ b/packages/contracts/notes-source-profile.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/notes-source-profile.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "surface",
+    "ingestMethods",
+    "preserveRawFirst",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "NotesSourceProfile" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": {
+      "type": "string",
+      "enum": ["apple", "microsoft", "google"]
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["icloud-notes", "onenote", "google-keep"]
+    },
+    "ingestMethods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "web-export",
+          "takeout-export",
+          "api-collector",
+          "local-app-export",
+          "trusted-device-collector",
+          "archive-bundle",
+          "pdf-export",
+          "html-export",
+          "json-export",
+          "screenshot-capture"
+        ]
+      },
+      "minItems": 1
+    },
+    "expectedMetadata": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "attachmentSupport": { "type": "boolean" },
+    "collaborationMetadata": { "type": "boolean" },
+    "preserveRawFirst": { "type": "boolean" },
+    "notes": { "type": "string" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/owned-media-attestation-record.schema.json
+++ b/packages/contracts/owned-media-attestation-record.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/owned-media-attestation-record.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "mediaRef",
+    "attestingSubjectRef",
+    "attestationScope",
+    "attestationStatus",
+    "privateUseAllowed",
+    "localDerivativeAllowed",
+    "publicDistributionStatus",
+    "attestedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "OwnedMediaAttestationRecord" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "mediaRef": { "type": "string" },
+    "sourceProfileRef": { "type": "string" },
+    "acquisitionRunRef": { "type": "string" },
+    "attestingSubjectRef": { "type": "string" },
+    "attestationScope": {
+      "type": "string",
+      "enum": ["personal-use", "creator-owned", "licensed-use", "public-domain", "open-license", "distribution-cleared", "unknown"]
+    },
+    "attestationStatus": {
+      "type": "string",
+      "enum": ["required", "captured", "rejected", "insufficient", "superseded"]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "contextRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "privateUseAllowed": { "type": "boolean" },
+    "localDerivativeAllowed": { "type": "boolean" },
+    "publicDistributionStatus": {
+      "type": "string",
+      "enum": ["blocked", "separate-clearance-required", "cleared", "not-applicable"]
+    },
+    "accessControlStatus": {
+      "type": "string",
+      "enum": ["none-observed", "metadata-only", "blocked", "unknown"]
+    },
+    "attestationTextDigest": { "type": "string" },
+    "notes": { "type": "string" },
+    "attestedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/owned-media-conversion-profile.schema.json
+++ b/packages/contracts/owned-media-conversion-profile.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/owned-media-conversion-profile.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "profileName",
+    "mediaKind",
+    "rawCustodyRequired",
+    "attestationRequired",
+    "distributionClearanceRequired",
+    "preferredAction",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "OwnedMediaConversionProfile" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "profileName": { "type": "string" },
+    "mediaKind": {
+      "type": "string",
+      "enum": ["audio", "video", "playlist", "metadata", "mixed"]
+    },
+    "rawCustodyRequired": { "type": "boolean" },
+    "attestationRequired": { "type": "boolean" },
+    "distributionClearanceRequired": { "type": "boolean" },
+    "preferredAction": {
+      "type": "string",
+      "enum": ["copy", "remux", "transcode", "metadata-only", "block"]
+    },
+    "targetContainer": { "type": "string" },
+    "targetCodec": { "type": "string" },
+    "metadataSidecar": { "type": "string" },
+    "subtitleTarget": { "type": "string" },
+    "budgetClass": {
+      "type": "string",
+      "enum": ["custody-only", "playback-ready", "archive-plus-portable"]
+    },
+    "failureStates": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "metadata-only",
+          "blocked-access-control",
+          "blocked-unsupported-format",
+          "blocked-storage-budget",
+          "failed-tool-error"
+        ]
+      }
+    },
+    "notes": { "type": "string" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/owned-media-source-profile.schema.json
+++ b/packages/contracts/owned-media-source-profile.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/owned-media-source-profile.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "surface",
+    "mediaKinds",
+    "ingestMethods",
+    "preserveRawFirst",
+    "drmPolicy",
+    "updatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "OwnedMediaSourceProfile" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "surface": { "type": "string" },
+    "mediaKinds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["music", "video", "voice-memo", "home-movie", "playlist", "podcast-archive", "photo-video", "other"]
+      },
+      "minItems": 1
+    },
+    "ingestMethods": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["local-library", "takeout-export", "cloud-drive", "photos-export", "device-export", "archive-folder", "nas-export", "external-disk", "metadata-only"]
+      },
+      "minItems": 1
+    },
+    "preferredTargets": {
+      "type": "object",
+      "properties": {
+        "audioArchival": { "type": "string" },
+        "audioPortable": { "type": "string" },
+        "videoArchivalContainer": { "type": "string" },
+        "videoCompatibilityContainer": { "type": "string" },
+        "metadataSidecar": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "expectedMetadata": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "preserveRawFirst": { "type": "boolean" },
+    "drmPolicy": {
+      "type": "string",
+      "enum": ["blocked-or-metadata-only", "authorized-export-only"]
+    },
+    "notes": { "type": "string" },
+    "updatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/playlist-migration-record.schema.json
+++ b/packages/contracts/playlist-migration-record.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/playlist-migration-record.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "playlistId",
+    "title",
+    "playlistType",
+    "rawEvidenceRef",
+    "entries",
+    "generatedAtUtc"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "PlaylistMigrationRecord" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "playlistId": { "type": "string" },
+    "title": { "type": "string" },
+    "playlistType": {
+      "type": "string",
+      "enum": ["music", "video", "mixed", "folder-derived", "unknown"]
+    },
+    "sourceLocator": { "type": "string" },
+    "rawEvidenceRef": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["position", "entryStatus", "originalLocator"],
+        "properties": {
+          "position": { "type": "integer", "minimum": 0 },
+          "entryStatus": {
+            "type": "string",
+            "enum": ["resolved", "missing-source", "duplicate-preserved", "blocked-access-control", "metadata-only", "unsupported", "pending"]
+          },
+          "originalLocator": { "type": "string" },
+          "canonicalBlobRef": { "type": "string" },
+          "title": { "type": "string" },
+          "artistOrCreator": { "type": "string" },
+          "durationSeconds": { "type": "number", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "outputPlaylistRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "unresolvedEntryCount": { "type": "integer", "minimum": 0 },
+    "duplicateEntryCount": { "type": "integer", "minimum": 0 },
+    "proofPackRef": { "type": "string" },
+    "notes": { "type": "string" },
+    "generatedAtUtc": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/proof-pack-summary.schema.json
+++ b/packages/contracts/proof-pack-summary.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/proof-pack-summary.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "proofPackId",
+    "migrationWaveId",
+    "status",
+    "generatedAtUtc",
+    "contents"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "ProofPackSummary" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "proofPackId": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "generated", "validated", "blocked", "superseded"]
+    },
+    "generatedAtUtc": { "type": "string", "format": "date-time" },
+    "contents": {
+      "type": "object",
+      "required": ["manifestRefs", "validationRefs", "sourceAliasReport", "mirrorParityReport"],
+      "properties": {
+        "manifestRefs": { "type": "array", "items": { "type": "string" } },
+        "validationRefs": { "type": "array", "items": { "type": "string" } },
+        "sourceAliasReport": { "type": "string" },
+        "mirrorParityReport": { "type": "string" },
+        "blockedObjectReport": { "type": "string" },
+        "openFormatConversionReport": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "eligibility": {
+      "type": "object",
+      "required": ["sourceDeletionEligible", "providerDowngradeEligible"],
+      "properties": {
+        "sourceDeletionEligible": { "type": "boolean" },
+        "providerDowngradeEligible": { "type": "boolean" },
+        "reason": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/provider-downgrade-plan.schema.json
+++ b/packages/contracts/provider-downgrade-plan.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/provider-downgrade-plan.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "planId",
+    "provider",
+    "currentState",
+    "targetState",
+    "planStatus",
+    "createdAtUtc",
+    "steps"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "ProviderDowngradePlan" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "planId": { "type": "string" },
+    "provider": { "type": "string" },
+    "currentState": { "type": "string" },
+    "targetState": { "type": "string" },
+    "planStatus": {
+      "type": "string",
+      "enum": ["draft", "ready", "blocked", "in-progress", "completed", "cancelled"]
+    },
+    "createdAtUtc": { "type": "string", "format": "date-time" },
+    "eligibilityRefs": { "type": "array", "items": { "type": "string" } },
+    "proofPackRefs": { "type": "array", "items": { "type": "string" } },
+    "riskSummary": {
+      "type": "object",
+      "properties": {
+        "dataLossRisk": { "type": "string", "enum": ["low", "medium", "high", "unknown"] },
+        "accountLockoutRisk": { "type": "string", "enum": ["low", "medium", "high", "unknown"] },
+        "workflowBreakageRisk": { "type": "string", "enum": ["low", "medium", "high", "unknown"] }
+      },
+      "additionalProperties": false
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["stepId", "description", "status"],
+        "properties": {
+          "stepId": { "type": "string" },
+          "description": { "type": "string" },
+          "status": { "type": "string", "enum": ["pending", "ready", "blocked", "done", "skipped"] },
+          "evidenceRef": { "type": "string" },
+          "blockerRef": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/provider-topology-snapshot.schema.json
+++ b/packages/contracts/provider-topology-snapshot.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/provider-topology-snapshot.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "provider",
+    "snapshotId",
+    "discoveredAtUtc",
+    "accounts",
+    "surfaces",
+    "confidence"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "ProviderTopologySnapshot" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "provider": { "type": "string" },
+    "snapshotId": { "type": "string" },
+    "discoveredAtUtc": { "type": "string", "format": "date-time" },
+    "accounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["accountRef", "accountType", "status"],
+        "properties": {
+          "accountRef": { "type": "string" },
+          "accountType": { "type": "string" },
+          "status": { "type": "string", "enum": ["active", "inactive", "unknown", "blocked"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "surfaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["surfaceId", "surfaceType", "discoveryStatus"],
+        "properties": {
+          "surfaceId": { "type": "string" },
+          "surfaceType": { "type": "string" },
+          "objectEstimate": { "type": "integer", "minimum": 0 },
+          "byteEstimate": { "type": "integer", "minimum": 0 },
+          "discoveryStatus": { "type": "string", "enum": ["discovered", "partial", "blocked", "not-found", "unknown"] },
+          "blockerRefs": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "exportMethods": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "confidence": {
+      "type": "object",
+      "required": ["score", "gaps"],
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "gaps": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/redaction-review-record.schema.json
+++ b/packages/contracts/redaction-review-record.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/redaction-review-record.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "reviewId",
+    "targetRef",
+    "reviewStatus",
+    "reviewedAtUtc",
+    "findings"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "RedactionReviewRecord" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "reviewId": { "type": "string" },
+    "targetRef": { "type": "string" },
+    "reviewStatus": { "type": "string", "enum": ["not-reviewed", "review-required", "redacted", "safe-for-export", "blocked"] },
+    "reviewedAtUtc": { "type": "string", "format": "date-time" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["findingType", "severity"],
+        "properties": {
+          "findingType": { "type": "string", "enum": ["secret", "personal-data", "third-party-data", "legal-sensitive", "medical-sensitive", "financial-sensitive", "location", "other"] },
+          "severity": { "type": "string", "enum": ["info", "warn", "error"] },
+          "fieldRef": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "redactedDerivativeRef": { "type": "string" },
+    "rawPreserved": { "type": "boolean" },
+    "exportAllowed": { "type": "boolean" },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/packages/contracts/source-alias-report.schema.json
+++ b/packages/contracts/source-alias-report.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/0.1.0/source-alias-report.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "specVersion",
+    "reportId",
+    "migrationWaveId",
+    "generatedAtUtc",
+    "aliases"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "const": "SourceAliasReport" },
+    "specVersion": { "type": "string", "pattern": "^0\\.1\\.\\d+$" },
+    "reportId": { "type": "string" },
+    "migrationWaveId": { "type": "string" },
+    "generatedAtUtc": { "type": "string", "format": "date-time" },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["aliasType", "sourceLocator", "canonicalBlobRef"],
+        "properties": {
+          "aliasType": { "type": "string", "enum": ["path", "provider-id", "revision-id", "playlist-id", "library-id", "archive-path", "message-id", "conversation-id", "other"] },
+          "sourceLocator": { "type": "string" },
+          "canonicalBlobRef": { "type": "string" },
+          "provider": { "type": "string" },
+          "surface": { "type": "string" },
+          "observedAtUtc": { "type": "string", "format": "date-time" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "uniqueBlobCount": { "type": "integer", "minimum": 0 },
+    "aliasCount": { "type": "integer", "minimum": 0 },
+    "duplicateAliasCount": { "type": "integer", "minimum": 0 },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate_ai_chat_export_contracts.py
+++ b/scripts/validate_ai_chat_export_contracts.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Validate Exodus AI chat export source and document fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_SCHEMA = ROOT / "packages" / "contracts" / "ai-chat-source-profile.schema.json"
+DOC_SCHEMA = ROOT / "packages" / "contracts" / "ai-chat-conversation-document.schema.json"
+SOURCE_EXAMPLES = [
+    ROOT / "examples" / "ai-chat-source-profile.chatgpt.example.json",
+    ROOT / "examples" / "ai-chat-source-profile.claude.example.json",
+]
+DOC_EXAMPLE = ROOT / "examples" / "ai-chat-conversation-document.example.json"
+REQUIRED_SURFACES = {"chatgpt", "claude"}
+
+
+def validate(schema_path: Path, example_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text())
+    example = json.loads(example_path.read_text())
+    errors = sorted(Draft202012Validator(schema).iter_errors(example), key=lambda err: list(err.path))
+    failures = []
+    for error in errors:
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+    seen_surfaces: set[str] = set()
+
+    for example_path in SOURCE_EXAMPLES:
+        if not example_path.exists():
+            failures.append(f"missing source example: {example_path.relative_to(ROOT)}")
+            continue
+        example = json.loads(example_path.read_text())
+        seen_surfaces.add(example.get("surface", ""))
+        failures.extend(validate(SOURCE_SCHEMA, example_path))
+        if example.get("preserveRawFirst") is not True:
+            failures.append(f"{example_path.relative_to(ROOT)} preserveRawFirst must be true")
+        if example.get("requiresRedactionReview") is not True:
+            failures.append(f"{example_path.relative_to(ROOT)} requiresRedactionReview must be true")
+
+    missing_surfaces = REQUIRED_SURFACES - seen_surfaces
+    if missing_surfaces:
+        failures.append(f"missing AI chat source surfaces: {sorted(missing_surfaces)}")
+
+    failures.extend(validate(DOC_SCHEMA, DOC_EXAMPLE))
+    doc = json.loads(DOC_EXAMPLE.read_text())
+    formats = {item.get("format") for item in doc.get("documentDerivatives", [])}
+    for required_format in ("markdown", "jsonl", "chunk-manifest"):
+        if required_format not in formats:
+            failures.append(f"conversation document missing derivative format: {required_format}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: AI chat export contract fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_all_evidence_fabric_contracts.py
+++ b/scripts/validate_all_evidence_fabric_contracts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run every Exodus evidence-fabric contract validator, including owned media."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATORS = [
+    ROOT / "scripts" / "validate_evidence_dashboard_state.py",
+    ROOT / "scripts" / "validate_evidence_fabric_dashboard_contracts.py",
+    ROOT / "scripts" / "validate_notes_source_profiles.py",
+    ROOT / "scripts" / "validate_owned_media_source_profile.py",
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for validator in VALIDATORS:
+        if not validator.exists():
+            failures.append(f"missing validator: {validator.relative_to(ROOT)}")
+            continue
+
+        result = subprocess.run(
+            [sys.executable, str(validator)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        print(result.stdout, end="")
+        if result.returncode != 0:
+            failures.append(f"validator failed: {validator.relative_to(ROOT)}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: all Exodus evidence-fabric contract validators passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_complete_evidence_fabric_contracts.py
+++ b/scripts/validate_complete_evidence_fabric_contracts.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run all Exodus evidence-fabric validators including owned-media attestation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATORS = [
+    "validate_evidence_dashboard_state.py",
+    "validate_evidence_fabric_dashboard_contracts.py",
+    "validate_notes_source_profiles.py",
+    "validate_owned_media_source_profile.py",
+    "validate_owned_media_attestation_record.py",
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for name in VALIDATORS:
+        path = ROOT / "scripts" / name
+        if not path.exists():
+            failures.append(f"missing validator: scripts/{name}")
+            continue
+        result = subprocess.run(
+            [sys.executable, str(path)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        print(result.stdout, end="")
+        if result.returncode != 0:
+            failures.append(f"validator failed: scripts/{name}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: complete Exodus evidence-fabric validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_conversation_reuse_policy.py
+++ b/scripts/validate_conversation_reuse_policy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate Exodus conversation reuse policy fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "conversation-reuse-policy.schema.json"
+EXAMPLE = ROOT / "examples" / "conversation-reuse-policy.example.json"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    example = json.loads(EXAMPLE.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{EXAMPLE.relative_to(ROOT)} {path}: {error.message}")
+
+    if example.get("reuseMode") != "blocked":
+        if example.get("citationRequired") is not True:
+            failures.append("non-blocked reuse must require citation")
+        if example.get("treatModelOutputsAsHistorical") is not True:
+            failures.append("model outputs must be treated as historical records")
+
+    if "sourceos-chat" in set(example.get("allowedTargets", [])) and not example.get("redactionRequired"):
+        failures.append("sourceos-chat reuse requires redaction review")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: conversation reuse policy fixture is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_conversion_and_redaction_records.py
+++ b/scripts/validate_conversion_and_redaction_records.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate Exodus conversion receipt and redaction review fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (
+        ROOT / "packages" / "contracts" / "conversion-receipt.schema.json",
+        ROOT / "examples" / "conversion-receipt.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "redaction-review-record.schema.json",
+        ROOT / "examples" / "redaction-review-record.example.json",
+    ),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text())
+    example = json.loads(example_path.read_text())
+    validator = Draft202012Validator(schema)
+    failures = []
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for schema_path, example_path in PAIRS:
+        failures.extend(validate_pair(schema_path, example_path))
+
+    conversion = json.loads((ROOT / "examples" / "conversion-receipt.example.json").read_text())
+    if conversion.get("status") == "succeeded":
+        if not conversion.get("outputBlobRef"):
+            failures.append("successful conversion must include outputBlobRef")
+        if conversion.get("rawCustodyPreserved") is not True:
+            failures.append("successful conversion must preserve raw custody")
+
+    redaction = json.loads((ROOT / "examples" / "redaction-review-record.example.json").read_text())
+    if redaction.get("reviewStatus") in {"review-required", "blocked"} and redaction.get("exportAllowed"):
+        failures.append("review-required or blocked redaction state must not allow export")
+    if redaction.get("rawPreserved") is not True:
+        failures.append("redaction review must preserve raw source")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: conversion and redaction fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_evidence_dashboard_state.py
+++ b/scripts/validate_evidence_dashboard_state.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Validate the Exodus EvidenceDashboardState example."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "evidence-dashboard-state.schema.json"
+EXAMPLE = ROOT / "examples" / "evidence-dashboard-state.example.json"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    example = json.loads(EXAMPLE.read_text())
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda err: list(err.path))
+    if errors:
+        for error in errors:
+            path = ".".join(str(part) for part in error.path) or "<root>"
+            print(f"ERR {path}: {error.message}")
+        return 1
+    print("OK: evidence dashboard state example is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_evidence_fabric_contracts.py
+++ b/scripts/validate_evidence_fabric_contracts.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Run all Exodus evidence-fabric contract validators."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATORS = [
+    ROOT / "scripts" / "validate_evidence_dashboard_state.py",
+    ROOT / "scripts" / "validate_evidence_fabric_dashboard_contracts.py",
+    ROOT / "scripts" / "validate_notes_source_profiles.py",
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for validator in VALIDATORS:
+        if not validator.exists():
+            failures.append(f"missing validator: {validator.relative_to(ROOT)}")
+            continue
+        result = subprocess.run(
+            [sys.executable, str(validator)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        print(result.stdout, end="")
+        if result.returncode != 0:
+            failures.append(f"validator failed: {validator.relative_to(ROOT)}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: all Exodus evidence-fabric contract validators passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_evidence_fabric_dashboard_contracts.py
+++ b/scripts/validate_evidence_fabric_dashboard_contracts.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validate Exodus evidence-fabric dashboard contract examples."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CONTRACTS = [
+    (
+        ROOT / "packages" / "contracts" / "evidence-dashboard-state.schema.json",
+        ROOT / "examples" / "evidence-dashboard-state.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "migration-wave-plan.schema.json",
+        ROOT / "examples" / "migration-wave-plan.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "proof-pack-summary.schema.json",
+        ROOT / "examples" / "proof-pack-summary.example.json",
+    ),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text())
+    example = json.loads(example_path.read_text())
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda err: list(err.path))
+    messages: list[str] = []
+    for error in errors:
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        messages.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+    return messages
+
+
+def main() -> int:
+    failures: list[str] = []
+    for schema_path, example_path in CONTRACTS:
+        if not schema_path.exists():
+            failures.append(f"missing schema: {schema_path.relative_to(ROOT)}")
+            continue
+        if not example_path.exists():
+            failures.append(f"missing example: {example_path.relative_to(ROOT)}")
+            continue
+        failures.extend(validate_pair(schema_path, example_path))
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: Exodus evidence-fabric dashboard contracts are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_exit_readiness_records.py
+++ b/scripts/validate_exit_readiness_records.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate Exodus deletion eligibility and provider downgrade fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (
+        ROOT / "packages" / "contracts" / "deletion-eligibility-record.schema.json",
+        ROOT / "examples" / "deletion-eligibility-record.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "provider-downgrade-plan.schema.json",
+        ROOT / "examples" / "provider-downgrade-plan.example.json",
+    ),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text())
+    example = json.loads(example_path.read_text())
+    validator = Draft202012Validator(schema)
+    failures = []
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for schema_path, example_path in PAIRS:
+        failures.extend(validate_pair(schema_path, example_path))
+
+    eligibility = json.loads((ROOT / "examples" / "deletion-eligibility-record.example.json").read_text())
+    checks = eligibility.get("checks", {})
+    all_checks_passed = all(bool(value) for value in checks.values())
+    if eligibility.get("eligibilityStatus") == "eligible" and not all_checks_passed:
+        failures.append("eligible deletion status requires every check to pass")
+    if eligibility.get("eligibilityStatus") == "cooling-off" and checks.get("coolingOffComplete"):
+        failures.append("cooling-off status should not have coolingOffComplete=true")
+
+    downgrade = json.loads((ROOT / "examples" / "provider-downgrade-plan.example.json").read_text())
+    steps = downgrade.get("steps", [])
+    if downgrade.get("planStatus") == "ready" and not downgrade.get("proofPackRefs"):
+        failures.append("ready downgrade plan requires proofPackRefs")
+    if not any(step.get("stepId") == "verify-proof-pack" for step in steps):
+        failures.append("provider downgrade plan must include verify-proof-pack step")
+    if not any(step.get("stepId") == "complete-cooling-off" for step in steps):
+        failures.append("provider downgrade plan must include complete-cooling-off step")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: exit readiness fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_exodus_evidence_fabric_all.py
+++ b/scripts/validate_exodus_evidence_fabric_all.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Run all Exodus evidence-fabric validators staged in the contract bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATORS = [
+    "validate_evidence_dashboard_state.py",
+    "validate_evidence_fabric_dashboard_contracts.py",
+    "validate_notes_source_profiles.py",
+    "validate_owned_media_source_profile.py",
+    "validate_owned_media_attestation_record.py",
+    "validate_owned_media_conversion_profiles.py",
+    "validate_playlist_migration_record.py",
+    "validate_ai_chat_export_contracts.py",
+    "validate_conversation_reuse_policy.py",
+    "validate_exodus_report_contracts.py",
+    "validate_conversion_and_redaction_records.py",
+    "validate_exit_readiness_records.py",
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for validator_name in VALIDATORS:
+        validator_path = ROOT / "scripts" / validator_name
+        if not validator_path.exists():
+            failures.append(f"missing validator: scripts/{validator_name}")
+            continue
+
+        result = subprocess.run(
+            [sys.executable, str(validator_path)],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        print(result.stdout, end="")
+        if result.returncode != 0:
+            failures.append(f"validator failed: scripts/{validator_name}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: all Exodus evidence-fabric validators passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_exodus_report_contracts.py
+++ b/scripts/validate_exodus_report_contracts.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate Exodus provider topology, source alias, and blocked object reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (
+        ROOT / "packages" / "contracts" / "provider-topology-snapshot.schema.json",
+        ROOT / "examples" / "provider-topology-snapshot.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "source-alias-report.schema.json",
+        ROOT / "examples" / "source-alias-report.example.json",
+    ),
+    (
+        ROOT / "packages" / "contracts" / "blocked-object-report.schema.json",
+        ROOT / "examples" / "blocked-object-report.example.json",
+    ),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text())
+    example = json.loads(example_path.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for schema_path, example_path in PAIRS:
+        if not schema_path.exists():
+            failures.append(f"missing schema: {schema_path.relative_to(ROOT)}")
+            continue
+        if not example_path.exists():
+            failures.append(f"missing example: {example_path.relative_to(ROOT)}")
+            continue
+        failures.extend(validate_pair(schema_path, example_path))
+
+    alias_example = json.loads((ROOT / "examples" / "source-alias-report.example.json").read_text())
+    if alias_example.get("aliasCount") != len(alias_example.get("aliases", [])):
+        failures.append("source alias report aliasCount must match aliases length")
+
+    blocked_example = json.loads((ROOT / "examples" / "blocked-object-report.example.json").read_text())
+    if blocked_example.get("blockedCount") != len(blocked_example.get("blockedObjects", [])):
+        failures.append("blocked object report blockedCount must match blockedObjects length")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: Exodus report contract fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_notes_source_profiles.py
+++ b/scripts/validate_notes_source_profiles.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Validate Exodus notes-source profile fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "notes-source-profile.schema.json"
+EXAMPLES = [
+    ROOT / "examples" / "notes-source-profile.example.json",
+    ROOT / "examples" / "notes-source-profile.icloud-notes.example.json",
+    ROOT / "examples" / "notes-source-profile.onenote.example.json",
+]
+REQUIRED_SURFACES = {"google-keep", "icloud-notes", "onenote"}
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+    seen_surfaces: set[str] = set()
+
+    for example_path in EXAMPLES:
+        if not example_path.exists():
+            failures.append(f"missing example: {example_path.relative_to(ROOT)}")
+            continue
+        example = json.loads(example_path.read_text())
+        seen_surfaces.add(example.get("surface", ""))
+        for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+            path = ".".join(str(part) for part in error.path) or "<root>"
+            failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+
+    missing = REQUIRED_SURFACES - seen_surfaces
+    if missing:
+        failures.append(f"missing required notes surfaces: {sorted(missing)}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: notes source profile fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_owned_media_attestation_record.py
+++ b/scripts/validate_owned_media_attestation_record.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Validate the owned-media attestation example."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "owned-media-attestation-record.schema.json"
+EXAMPLE = ROOT / "examples" / "owned-media-attestation-record.example.json"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    example = json.loads(EXAMPLE.read_text())
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(example),
+        key=lambda err: list(err.path),
+    )
+    failures = []
+    for error in errors:
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{path}: {error.message}")
+
+    if example.get("attestationStatus") == "captured" and not example.get("privateUseAllowed"):
+        failures.append("captured attestation must allow private use")
+    if example.get("publicDistributionStatus") == "cleared" and example.get("attestationScope") == "personal-use":
+        failures.append("personal-use attestation must not clear public distribution")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: owned media attestation example is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_owned_media_conversion_profiles.py
+++ b/scripts/validate_owned_media_conversion_profiles.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate owned-media conversion profile fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "owned-media-conversion-profile.schema.json"
+EXAMPLES = sorted((ROOT / "examples").glob("owned-media-conversion-profile.*.example.json"))
+
+REQUIRED_PROFILES = {
+    "audio-archive-flac",
+    "audio-portable-opus",
+    "video-archive-mkv",
+    "video-compatible-mp4",
+}
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+    seen_profiles: set[str] = set()
+
+    if not EXAMPLES:
+        failures.append("no owned-media conversion profile examples found")
+
+    for example_path in EXAMPLES:
+        example = json.loads(example_path.read_text())
+        seen_profiles.add(example.get("profileName", ""))
+        for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+            path = ".".join(str(part) for part in error.path) or "<root>"
+            failures.append(f"{example_path.relative_to(ROOT)} {path}: {error.message}")
+        if example.get("rawCustodyRequired") is not True:
+            failures.append(f"{example_path.relative_to(ROOT)} rawCustodyRequired must be true")
+        if example.get("attestationRequired") is not True:
+            failures.append(f"{example_path.relative_to(ROOT)} attestationRequired must be true")
+        if example.get("distributionClearanceRequired") is not False:
+            failures.append(f"{example_path.relative_to(ROOT)} private conversion profiles must not require distribution clearance")
+
+    missing_profiles = REQUIRED_PROFILES - seen_profiles
+    if missing_profiles:
+        failures.append(f"missing required profiles: {sorted(missing_profiles)}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: owned media conversion profile fixtures are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_owned_media_source_profile.py
+++ b/scripts/validate_owned_media_source_profile.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate Exodus owned-media source profile fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "owned-media-source-profile.schema.json"
+EXAMPLE = ROOT / "examples" / "owned-media-source-profile.example.json"
+
+REQUIRED_MEDIA_KINDS = {"music", "video"}
+REQUIRED_TARGETS = {
+    "audioArchival",
+    "audioPortable",
+    "videoArchivalContainer",
+    "videoCompatibilityContainer",
+    "metadataSidecar",
+}
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    example = json.loads(EXAMPLE.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{EXAMPLE.relative_to(ROOT)} {path}: {error.message}")
+
+    media_kinds = set(example.get("mediaKinds", []))
+    missing_media = REQUIRED_MEDIA_KINDS - media_kinds
+    if missing_media:
+        failures.append(f"missing required media kinds: {sorted(missing_media)}")
+
+    preferred_targets = set((example.get("preferredTargets") or {}).keys())
+    missing_targets = REQUIRED_TARGETS - preferred_targets
+    if missing_targets:
+        failures.append(f"missing required conversion targets: {sorted(missing_targets)}")
+
+    if example.get("preserveRawFirst") is not True:
+        failures.append("preserveRawFirst must be true")
+
+    if example.get("drmPolicy") not in {"blocked-or-metadata-only", "authorized-export-only"}:
+        failures.append("drmPolicy must block bypass behavior")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: owned media source profile fixture is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_playlist_migration_record.py
+++ b/scripts/validate_playlist_migration_record.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Validate Exodus playlist migration record fixture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "packages" / "contracts" / "playlist-migration-record.schema.json"
+EXAMPLE = ROOT / "examples" / "playlist-migration-record.example.json"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text())
+    example = json.loads(EXAMPLE.read_text())
+    validator = Draft202012Validator(schema)
+    failures: list[str] = []
+
+    for error in sorted(validator.iter_errors(example), key=lambda err: list(err.path)):
+        path = ".".join(str(part) for part in error.path) or "<root>"
+        failures.append(f"{EXAMPLE.relative_to(ROOT)} {path}: {error.message}")
+
+    positions = [entry.get("position") for entry in example.get("entries", [])]
+    if positions != sorted(positions):
+        failures.append("playlist entry positions must remain sorted")
+
+    unresolved = sum(1 for entry in example.get("entries", []) if entry.get("entryStatus") != "resolved")
+    if example.get("unresolvedEntryCount") != unresolved:
+        failures.append("unresolvedEntryCount must match unresolved entries")
+
+    if not example.get("rawEvidenceRef"):
+        failures.append("rawEvidenceRef is required for playlist custody")
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}")
+        return 1
+
+    print("OK: playlist migration record fixture is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the initial Exodus evidence-fabric contract bootstrap: dashboard state, migration planning, proof packs, provider/source coverage, notes, owned media, playlists, AI chat exports, report/visibility records, conversion/redaction records, and exit-readiness records.

## What this PR adds

### Core dashboard and migration contracts
- `docs/evidence-fabric-integration.md`
- `packages/contracts/evidence-dashboard-state.schema.json`
- `packages/contracts/migration-wave-plan.schema.json`
- `packages/contracts/proof-pack-summary.schema.json`

### Provider/source coverage
- `backlog/provider-coverage-roadmap.md`
- `packages/contracts/provider-topology-snapshot.schema.json`
- `packages/contracts/source-alias-report.schema.json`
- `packages/contracts/blocked-object-report.schema.json`

### Notes and AI chat exports
- `docs/notes-provider-ingest.md`
- `packages/contracts/notes-source-profile.schema.json`
- `docs/ai-chat-export-ingest.md`
- `packages/contracts/ai-chat-source-profile.schema.json`
- `packages/contracts/ai-chat-conversation-document.schema.json`
- `packages/contracts/conversation-reuse-policy.schema.json`

### Owned media, playlists, and attestation
- `docs/owned-media-ingest.md`
- `docs/owned-media-export-conversion-architecture.md`
- `docs/owned-media-ownership-attestation.md`
- `packages/contracts/owned-media-source-profile.schema.json`
- `packages/contracts/owned-media-conversion-profile.schema.json`
- `packages/contracts/owned-media-attestation-record.schema.json`
- `packages/contracts/playlist-migration-record.schema.json`

### Receipts, redaction, and exit readiness
- `packages/contracts/conversion-receipt.schema.json`
- `packages/contracts/redaction-review-record.schema.json`
- `packages/contracts/deletion-eligibility-record.schema.json`
- `packages/contracts/provider-downgrade-plan.schema.json`

### Examples and validators
- example fixtures for every contract family
- validators for each thematic group
- final aggregate validator: `scripts/validate_exodus_evidence_fabric_all.py`
- `Makefile` wiring so `make validate` runs the final aggregate evidence-fabric validator

## Design posture

- Source systems are ingress only.
- Raw custody precedes parsing, conversion, chunking, redaction, or semantic projection.
- Provider IDs, paths, playlist IDs, conversation IDs, and library IDs are source aliases, not canonical truth.
- User-owned media uses attestation plus evidence/context capture for private migration and local Linux-ready derivatives.
- Public/marketplace distribution remains separately gated.
- Access-control-limited media is blocked or metadata-only; Exodus does not bypass access controls.
- AI chat exports become historical conversation documents, not verified facts.
- Proof packs, source aliases, blocked objects, conversion receipts, redaction reviews, and deletion/downgrade readiness are all explicit records.

## Validation

Run:

```bash
make validate
```

This runs:

```bash
python3 scripts/validate_examples.py
python3 scripts/validate_exodus_evidence_fabric_all.py
```

## Boundary

Exodus owns user experience, migration planning, scoring, proof summaries, and provider-exit guidance.

The evidence fabric owns raw custody, hash identity, source alias preservation, manifests, parser runs, and validation records.

## Follow-on

1. split this bootstrap into dedicated implementation repos when repo creation is available;
2. implement `evidence-contracts`, `evidence-broker`, and `evidence-storage-infra`;
3. add live dashboard panels against these fixtures;
4. add connector-specific ingest implementations for local files, Google Drive, iCloud Drive, email, notes, AI chat exports, and owned media.