### PR TITLE
Implement synthetic-safe exodus intake acquisition path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
         run: python3 scripts/validate_examples.py
       - name: Validate Phase 0 metadata schemas
         run: python3 scripts/validate_phase0_schemas.py
-      - name: Compile benchmark scripts
-        run: python3 -m py_compile packages/processing/benchmarks/deterministic_vs_hnet/run_benchmark.py packages/processing/benchmarks/deterministic_vs_hnet/score_run.py
+      - name: Validate synthetic intake path
+        run: python3 scripts/validate_intake_fixture.py
+      - name: Compile intake and benchmark scripts
+        run: python3 -m py_compile scripts/exodus_intake.py scripts/validate_intake_fixture.py packages/processing/benchmarks/deterministic_vs_hnet/run_benchmark.py packages/processing/benchmarks/deterministic_vs_hnet/score_run.py
       - name: Check critical docs exist
         run: |
           test -f docs/phases.md

--- a/docs/phase1-exodus-intake.md
+++ b/docs/phase1-exodus-intake.md
@@ -1,0 +1,46 @@
+# Phase 1 Exodus Intake Acquisition Path
+
+Status: initial synthetic-safe implementation
+Issue: #16
+
+This document records the first operational intake path for Exodus metadata standards.
+
+## What exists
+
+`scripts/exodus_intake.py` accepts a local artifact path and explicit source metadata, then writes:
+
+- an EvidenceArtifact-compatible JSON record;
+- an initial CustodyEvent-compatible JSON record with `event_type=Intake`.
+
+The command computes SHA-256 over raw file bytes using the Python standard library. BLAKE3 is computed only when the optional `blake3` Python package is available. If BLAKE3 is unavailable, callers must explicitly pass `--allow-pending-blake3`; the command writes a zero-hash sentinel, marks the record `PendingVerification`, and records that BLAKE3 is unavailable in `hash_computed_by`.
+
+## Discipline boundary
+
+A `PendingVerification` record is not an authenticated legal-custody artifact. It is an intake metadata draft preserving raw-byte SHA-256 and source metadata until full BLAKE3 tooling and custody sealing are available.
+
+No real forensic evidence is committed to the repository. The test fixture under `examples/intake/` is synthetic.
+
+## Smoke test
+
+Run:
+
+```bash
+python3 scripts/validate_intake_fixture.py
+```
+
+The smoke test verifies that the command:
+
+- preserves the original filename;
+- computes SHA-256 from raw bytes;
+- writes an initial Landing-zone EvidenceArtifact record;
+- writes a matching Intake CustodyEvent;
+- uses only synthetic fixture data.
+
+## Remaining work
+
+- Add approved BLAKE3 dependency/tooling.
+- Add stronger JSON Schema validation after dependency policy is set.
+- Add account registry integration for CHK-09.
+- Add TriTRPC BEACON_COMMIT receipts.
+- Add immutable object storage backing and explicit hash manifests.
+- Keep real evidence outside the public repo.

--- a/examples/intake/sample-console.txt
+++ b/examples/intake/sample-console.txt
@@ -1,0 +1,3 @@
+2026-01-21 11:46:00.000 quick-check completed: filesystem clean
+2026-01-21 11:46:01.000 live mounted containers skipped by design
+2026-01-21 11:46:02.000 software update policy migration observed

--- a/scripts/exodus_intake.py
+++ b/scripts/exodus_intake.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Synthetic-safe Exodus artifact intake command.
+
+This command creates an EvidenceArtifact-compatible metadata record and an
+initial CustodyEvent-compatible record for a local file. It intentionally avoids
+real evidence assumptions: callers must provide source metadata explicitly and
+BLAKE3 is only used when the optional dependency is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+ZERO_HASH_32 = "0" * 64
+VERSION = "exodus-intake-v0.1.0"
+
+ARTIFACT_CLASSES = [
+    "RawLog",
+    "ConsolePaste",
+    "Spindump",
+    "BinaryPlist",
+    "EmailThread",
+    "LegalFiling",
+    "AnalysisReport",
+    "DerivedReport",
+    "AuditRecord",
+    "NetworkCapture",
+    "FirmwareDump",
+    "AppleDataArchive",
+    "Other",
+]
+
+SOURCE_PLATFORMS = [
+    "GoogleDrive",
+    "GmailThread",
+    "iCloudDrive",
+    "LocalFilesystem",
+    "AppleDataArchive",
+    "TerminalSession",
+    "BrowserConsole",
+    "NetworkCapture",
+    "Other",
+]
+
+CAPTURE_METHODS = ["LiveCapture", "PanicSave", "ScheduledExport", "ManualCopy", "AgentExport", "Unknown"]
+
+
+def now_micros() -> int:
+    return time.time_ns() // 1_000
+
+
+def read_bytes(path: Path) -> bytes:
+    if not path.exists():
+        raise SystemExit(f"input path does not exist: {path}")
+    if not path.is_file():
+        raise SystemExit(f"input path is not a file: {path}")
+    return path.read_bytes()
+
+
+def compute_blake3(raw: bytes) -> tuple[str, str]:
+    try:
+        import blake3  # type: ignore
+    except Exception:
+        return ZERO_HASH_32, "unavailable"
+    return blake3.blake3(raw).hexdigest(), "computed"
+
+
+def guess_mime(path: Path) -> str:
+    guessed, _ = mimetypes.guess_type(path.name)
+    return guessed or "application/octet-stream"
+
+
+def write_json(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_records(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    input_path = Path(args.input).resolve()
+    raw = read_bytes(input_path)
+    timestamp = args.timestamp_micros or now_micros()
+    uploaded_at = args.uploaded_at_micros or timestamp
+    artifact_id = args.artifact_id or str(uuid.uuid4())
+    event_id = args.event_id or str(uuid.uuid4())
+
+    sha256 = hashlib.sha256(raw).hexdigest()
+    blake3_hash, blake3_status = compute_blake3(raw)
+    if blake3_status == "unavailable" and not args.allow_pending_blake3:
+        raise SystemExit(
+            "BLAKE3 dependency unavailable. Re-run with --allow-pending-blake3 to write "
+            "a PendingVerification record with a zero-hash sentinel."
+        )
+
+    integrity_status = "PendingVerification" if blake3_status == "unavailable" else "Verified"
+    custody_status = "PendingVerification" if blake3_status == "unavailable" else "Intact"
+    hash_tool = args.hash_computed_by or VERSION
+
+    artifact = {
+        "artifact_id": artifact_id,
+        "artifact_class": args.artifact_class,
+        "canonicalization_spec": args.canonicalization_spec,
+        "capture_method": args.capture_method,
+        "chain_of_trust": [],
+        "containing_folder": args.containing_folder,
+        "corpus_id": args.corpus_id,
+        "counter_explanations": [],
+        "custody_status": custody_status,
+        "evidence_class": args.evidence_class,
+        "evidence_grade": "E3" if integrity_status == "Verified" else "E2",
+        "exhibit_id": args.exhibit_id,
+        "file_size_bytes": len(raw),
+        "hash_blake3": blake3_hash,
+        "hash_computed_at_micros": timestamp,
+        "hash_computed_by": f"{hash_tool}; blake3={blake3_status}",
+        "hash_md5": None,
+        "hash_sha256": sha256,
+        "hypothesis_ids": [],
+        "incident_date_range": None,
+        "integrity_status": integrity_status,
+        "layer_citations": [],
+        "mime_type": args.mime_type or guess_mime(input_path),
+        "null_hypothesis_ids": [],
+        "observed_at_micros": timestamp,
+        "original_filename": input_path.name,
+        "owning_zone": "Landing",
+        "parent_artifact_id": None,
+        "producing_tool": args.producing_tool,
+        "security_label": args.security_label,
+        "serializer_version": args.serializer_version,
+        "signer_atom": None,
+        "source_account": args.source_account,
+        "source_path_or_id": args.source_path_or_id,
+        "source_platform": args.source_platform,
+        "txn_created": f"txn-local-{timestamp}",
+        "uploaded_at_micros": uploaded_at,
+        "valid_from_micros": None,
+        "valid_to_micros": None,
+        "witness_retention": args.witness_retention,
+    }
+
+    event = {
+        "actor_id": args.actor_id,
+        "actor_type": "IntakeProcess",
+        "artifact_id": artifact_id,
+        "custody_status": custody_status,
+        "event_id": event_id,
+        "event_type": "Intake",
+        "hash_at_event": blake3_hash,
+        "hypothesis_ids": [],
+        "note": None if blake3_status == "computed" else "BLAKE3 unavailable; zero hash sentinel; do not treat as verified.",
+        "recipient_id": None,
+        "timestamp_micros": timestamp,
+        "tool_name": VERSION,
+        "trpc_commit_receipt": None,
+        "zone_from": None,
+        "zone_to": "Landing",
+    }
+
+    return artifact, event
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create Exodus intake metadata for a local artifact.")
+    parser.add_argument("input", help="Local artifact path. Use only synthetic fixtures in repo tests.")
+    parser.add_argument("--out-dir", required=True, help="Output directory for metadata records.")
+    parser.add_argument("--corpus-id", required=True)
+    parser.add_argument("--exhibit-id", required=True)
+    parser.add_argument("--source-account", required=True)
+    parser.add_argument("--source-platform", required=True, choices=SOURCE_PLATFORMS)
+    parser.add_argument("--source-path-or-id", required=True)
+    parser.add_argument("--artifact-class", default="Other", choices=ARTIFACT_CLASSES)
+    parser.add_argument("--capture-method", default="ManualCopy", choices=CAPTURE_METHODS)
+    parser.add_argument("--artifact-id")
+    parser.add_argument("--event-id")
+    parser.add_argument("--timestamp-micros", type=int)
+    parser.add_argument("--uploaded-at-micros", type=int)
+    parser.add_argument("--mime-type")
+    parser.add_argument("--containing-folder")
+    parser.add_argument("--producing-tool")
+    parser.add_argument("--evidence-class", default="Primary", choices=["Primary", "Derived", "Duplicate", "Reference", "Unknown"])
+    parser.add_argument("--security-label", default="Internal", choices=["Public", "Internal", "Confidential", "Restricted", "LocalOnly"])
+    parser.add_argument("--witness-retention", default="LocalOnly", choices=["LocalOnly", "ExportableToLegalCounsel", "ExportableUnderProtectiveOrder", "PublicRecord"])
+    parser.add_argument("--canonicalization-spec", default="CANON-v0.1")
+    parser.add_argument("--serializer-version", default="serializer-v0.1.0")
+    parser.add_argument("--hash-computed-by", default=VERSION)
+    parser.add_argument("--actor-id", default=VERSION)
+    parser.add_argument("--allow-pending-blake3", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    artifact, event = build_records(args)
+    out_dir = Path(args.out_dir)
+    write_json(out_dir / f"{args.exhibit_id}.evidence-artifact.json", artifact)
+    write_json(out_dir / f"{args.exhibit_id}.custody-event.intake.json", event)
+    print(json.dumps({"artifact": artifact["artifact_id"], "evidence_grade": artifact["evidence_grade"], "integrity_status": artifact["integrity_status"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_intake_fixture.py
+++ b/scripts/validate_intake_fixture.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Run a synthetic exodus-intake smoke test.
+
+This test intentionally operates only on a synthetic fixture committed under
+examples/intake. It verifies that the intake command computes SHA-256 over raw
+bytes, preserves the original filename, and writes initial metadata/custody
+records before any examination output exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "examples" / "intake" / "sample-console.txt"
+EXPECTED_SHA256 = hashlib.sha256(SOURCE.read_bytes()).hexdigest()
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp)
+        cmd = [
+            sys.executable,
+            str(ROOT / "scripts" / "exodus_intake.py"),
+            str(SOURCE),
+            "--out-dir",
+            str(out_dir),
+            "--corpus-id",
+            "SP-SYNTHETIC-TESTS",
+            "--exhibit-id",
+            "AF-9001",
+            "--source-account",
+            "synthetic@socioprophet.invalid",
+            "--source-platform",
+            "LocalFilesystem",
+            "--source-path-or-id",
+            "examples/intake/sample-console.txt",
+            "--artifact-class",
+            "ConsolePaste",
+            "--capture-method",
+            "ManualCopy",
+            "--artifact-id",
+            "018f3f72-6b79-7c35-8f7d-4a3a7d2d9001",
+            "--event-id",
+            "018f3f72-6b79-7c35-8f7d-4a3a7d2d9002",
+            "--timestamp-micros",
+            "1780000000000000",
+            "--allow-pending-blake3",
+        ]
+        subprocess.run(cmd, cwd=ROOT, check=True)
+
+        artifact = load_json(out_dir / "AF-9001.evidence-artifact.json")
+        event = load_json(out_dir / "AF-9001.custody-event.intake.json")
+
+    assert artifact["original_filename"] == "sample-console.txt"
+    assert artifact["hash_sha256"] == EXPECTED_SHA256
+    assert len(artifact["hash_blake3"]) == 64
+    assert artifact["integrity_status"] in {"Verified", "PendingVerification"}
+    assert artifact["owning_zone"] == "Landing"
+    assert artifact["source_path_or_id"] == "examples/intake/sample-console.txt"
+    assert event["event_type"] == "Intake"
+    assert event["artifact_id"] == artifact["artifact_id"]
+    assert event["zone_to"] == "Landing"
+    assert event["hash_at_event"] == artifact["hash_blake3"]
+
+    print("validated synthetic exodus-intake acquisition path")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the first Phase 1 operational intake path from #16.

This PR adds:

- `scripts/exodus_intake.py` — synthetic-safe local artifact intake command.
- `scripts/validate_intake_fixture.py` — synthetic smoke test for raw-byte acquisition metadata.
- `examples/intake/sample-console.txt` — synthetic source fixture only; not real evidence.
- `docs/phase1-exodus-intake.md` — discipline boundaries and remaining work.
- CI wiring to run the intake smoke test and compile the intake script.

## Behavior

`exodus_intake.py` accepts a local artifact and explicit source metadata, then writes:

- an EvidenceArtifact-compatible JSON record;
- an Intake CustodyEvent-compatible JSON record.

The command computes SHA-256 over raw bytes with the standard library. BLAKE3 is computed only if the optional `blake3` package is available. If unavailable, the caller must explicitly pass `--allow-pending-blake3`; the command writes a zero-hash sentinel, marks the record `PendingVerification`, and records that BLAKE3 is unavailable.

## Boundaries

This does not commit real forensic evidence. It does not implement HellGraph signing, TriTRPC `BEACON_COMMIT` receipts, account registry integration, immutable object storage, or complete legal ForensicBundle generation.

## Validation

Expected checks:

```bash
python3 scripts/validate_examples.py
python3 scripts/validate_phase0_schemas.py
python3 scripts/validate_intake_fixture.py
python3 -m py_compile scripts/exodus_intake.py scripts/validate_intake_fixture.py
```

Closes #16.