### PR TITLE
Add synthetic Exodus Migration Workroom demo fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
         run: python3 scripts/validate_phase0_schemas.py
       - name: Validate synthetic intake path
         run: python3 scripts/validate_intake_fixture.py
-      - name: Compile intake and benchmark scripts
-        run: python3 -m py_compile scripts/exodus_intake.py scripts/validate_intake_fixture.py packages/processing/benchmarks/deterministic_vs_hnet/run_benchmark.py packages/processing/benchmarks/deterministic_vs_hnet/score_run.py
+      - name: Validate synthetic Exodus workroom demo
+        run: python3 scripts/validate_exodus_demo.py
+      - name: Compile intake, demo, and benchmark scripts
+        run: python3 -m py_compile scripts/exodus_intake.py scripts/validate_intake_fixture.py scripts/validate_exodus_demo.py packages/processing/benchmarks/deterministic_vs_hnet/run_benchmark.py packages/processing/benchmarks/deterministic_vs_hnet/score_run.py
       - name: Check critical docs exist
         run: |
           test -f docs/phases.md

--- a/docs/synthetic-workroom-demo.md
+++ b/docs/synthetic-workroom-demo.md
@@ -1,0 +1,96 @@
+# Synthetic Exodus Migration Workroom demo
+
+Status: synthetic v0 fixture.
+
+This document describes the Exodus-side fixture for the governed Exodus Migration Workroom demo tracked from `SocioProphet/sociosphere#478`.
+
+## Boundary
+
+This is not a real-provider extraction demo.
+
+The fixture:
+
+- uses no Apple, Google, or Microsoft credentials;
+- performs no live provider API calls;
+- performs no destructive actions;
+- performs no provider-side writes;
+- uses deterministic synthetic data only.
+
+## Files
+
+- `schemas/exodus-run.v0.schema.json` — canonical schema for the synthetic Exodus run object.
+- `examples/synthetic-tenant-a/exodus-run.json` — synthetic Apple/Google/Microsoft exit-readiness run.
+- `scripts/validate_exodus_demo.py` — offline validator and cross-reference checker.
+
+## What the fixture proves
+
+The fixture proves that Exodus can represent a synthetic migration run with:
+
+- provider topology for Apple, Google, and Microsoft;
+- account/root inventory;
+- asset census by provider and domain;
+- export ledger and evidence references;
+- ERI score and PCS-by-provider score explanations;
+- blockers;
+- recommendations;
+- Phase 2 budget proposal waves.
+
+## What the fixture does not prove
+
+The fixture does not prove:
+
+- real provider ingestion;
+- credentialed connector operation;
+- export automation;
+- chain-of-custody sealing for real evidence;
+- migration execution;
+- UI readiness.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/validate_exodus_demo.py
+```
+
+The validator checks:
+
+- schema shape when `jsonschema` is available;
+- synthetic boundary flags;
+- Apple/Google/Microsoft provider presence;
+- account/provider references;
+- asset/provider references;
+- evidence/provider references;
+- score/evidence references;
+- blocker/evidence references;
+- recommendation dependencies and evidence references;
+- budget wave/provider/evidence references.
+
+## Workspace bridge
+
+The next repository in the demo sequence is `SocioProphet/prophet-workspace`.
+
+The workspace bridge should wrap this Exodus run in a Professional Workroom with references to:
+
+- the Exodus run fixture;
+- provider topology;
+- asset census;
+- export ledger;
+- ERI/PCS score explanations;
+- blockers;
+- recommendations;
+- Phase 2 budget proposal;
+- generated report/dashboard artifacts through the Office Plane.
+
+## Sociosphere bridge
+
+The final repository in the v0 sequence is `SocioProphet/sociosphere`.
+
+Sociosphere should record how the Exodus fixture and Workspace workroom map into the control-plane state model:
+
+- declared state;
+- observed state;
+- disposition state;
+- summary state;
+- controlled mutation boundaries.

--- a/examples/synthetic-tenant-a/exodus-run.json
+++ b/examples/synthetic-tenant-a/exodus-run.json
@@ -1,0 +1,270 @@
+{
+  "schema_version": "exodus.run.v0",
+  "run_id": "exodus-run-synthetic-tenant-a-001",
+  "tenant_id": "synthetic-tenant-a",
+  "generated_at": "2026-06-08T12:30:00Z",
+  "phase": "phase_2_plan_budget",
+  "demo_boundary": {
+    "synthetic": true,
+    "live_credentials_required": false,
+    "destructive_actions_allowed": false,
+    "provider_side_writes_allowed": false,
+    "notes": "Synthetic fixture for Exodus Migration Workroom demo v0. No real provider accounts, credentials, exports, or destructive actions are used."
+  },
+  "providers": [
+    {
+      "provider_id": "provider.apple",
+      "name": "Apple",
+      "domains": ["identity", "storage", "photos", "notes", "calendar", "contacts", "assistant_workflows"],
+      "control_surfaces": ["Apple ID", "iCloud Drive", "Photos", "Notes", "Calendar", "Contacts", "Siri Shortcuts"],
+      "confidence": "medium"
+    },
+    {
+      "provider_id": "provider.google",
+      "name": "Google",
+      "domains": ["identity", "mail", "storage", "office_docs", "calendar", "contacts", "chat", "assistant_workflows"],
+      "control_surfaces": ["Google Account", "Gmail", "Drive", "Docs", "Calendar", "Contacts", "Chat", "Gemini Workspace"],
+      "confidence": "high"
+    },
+    {
+      "provider_id": "provider.microsoft",
+      "name": "Microsoft",
+      "domains": ["identity", "mail", "storage", "office_docs", "calendar", "chat", "meetings"],
+      "control_surfaces": ["Microsoft Entra ID", "Outlook", "OneDrive", "SharePoint", "Office", "Teams"],
+      "confidence": "high"
+    }
+  ],
+  "accounts": [
+    {
+      "account_id": "acct.apple.primary",
+      "provider_ref": "provider.apple",
+      "label": "Synthetic Apple personal estate",
+      "root_refs": ["root.apple.icloud-drive", "root.apple.photos", "root.apple.notes"]
+    },
+    {
+      "account_id": "acct.google.workspace",
+      "provider_ref": "provider.google",
+      "label": "Synthetic Google Workspace estate",
+      "root_refs": ["root.google.drive", "root.google.gmail", "root.google.calendar"]
+    },
+    {
+      "account_id": "acct.microsoft.work",
+      "provider_ref": "provider.microsoft",
+      "label": "Synthetic Microsoft 365 estate",
+      "root_refs": ["root.microsoft.onedrive", "root.microsoft.outlook", "root.microsoft.teams"]
+    }
+  ],
+  "asset_census": [
+    {
+      "asset_collection_id": "assets.apple.icloud-drive.docs",
+      "provider_ref": "provider.apple",
+      "domain": "storage",
+      "asset_count": 4200,
+      "byte_count": 18874368000,
+      "exportability": "partial",
+      "temperature": "warm"
+    },
+    {
+      "asset_collection_id": "assets.apple.photos.library",
+      "provider_ref": "provider.apple",
+      "domain": "photos",
+      "asset_count": 31800,
+      "byte_count": 257698037760,
+      "exportability": "partial",
+      "temperature": "cold"
+    },
+    {
+      "asset_collection_id": "assets.google.gmail",
+      "provider_ref": "provider.google",
+      "domain": "mail",
+      "asset_count": 128000,
+      "byte_count": 64424509440,
+      "exportability": "exportable",
+      "temperature": "hot"
+    },
+    {
+      "asset_collection_id": "assets.google.drive.docs",
+      "provider_ref": "provider.google",
+      "domain": "office_docs",
+      "asset_count": 9400,
+      "byte_count": 32212254720,
+      "exportability": "partial",
+      "temperature": "hot"
+    },
+    {
+      "asset_collection_id": "assets.microsoft.sharepoint.office",
+      "provider_ref": "provider.microsoft",
+      "domain": "office_docs",
+      "asset_count": 15600,
+      "byte_count": 91268055040,
+      "exportability": "exportable",
+      "temperature": "hot"
+    },
+    {
+      "asset_collection_id": "assets.microsoft.teams.chat",
+      "provider_ref": "provider.microsoft",
+      "domain": "chat",
+      "asset_count": 78000,
+      "byte_count": 8589934592,
+      "exportability": "blocked",
+      "temperature": "warm"
+    }
+  ],
+  "export_ledger": [
+    {
+      "evidence_id": "ev.apple.icloud-drive.inventory.v1",
+      "provider_ref": "provider.apple",
+      "domain": "storage",
+      "artifact_class": "ProviderInventoryManifest",
+      "hash_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "validation_status": "synthetic_verified"
+    },
+    {
+      "evidence_id": "ev.google.takeout.manifest.v1",
+      "provider_ref": "provider.google",
+      "domain": "mail",
+      "artifact_class": "ExportManifest",
+      "hash_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "validation_status": "synthetic_verified"
+    },
+    {
+      "evidence_id": "ev.google.drive.exportability.v1",
+      "provider_ref": "provider.google",
+      "domain": "office_docs",
+      "artifact_class": "ExportabilityReport",
+      "hash_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "validation_status": "synthetic_verified"
+    },
+    {
+      "evidence_id": "ev.microsoft.graph.delta.snapshot.v1",
+      "provider_ref": "provider.microsoft",
+      "domain": "office_docs",
+      "artifact_class": "DeltaSnapshot",
+      "hash_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "validation_status": "synthetic_verified"
+    },
+    {
+      "evidence_id": "ev.microsoft.teams.export.blocker.v1",
+      "provider_ref": "provider.microsoft",
+      "domain": "chat",
+      "artifact_class": "BlockerEvidence",
+      "hash_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "validation_status": "synthetic_verified"
+    }
+  ],
+  "scores": {
+    "eri": {
+      "score": 0.42,
+      "label": "Constrained but actionable",
+      "explanation": "The estate has strong export paths for mail and Microsoft office assets, but remains constrained by Apple media/library exports, Google native document conversion, Microsoft Teams chat exportability, and identity dependency concentration.",
+      "evidence_refs": ["ev.google.takeout.manifest.v1", "ev.microsoft.graph.delta.snapshot.v1", "ev.microsoft.teams.export.blocker.v1"]
+    },
+    "pcs_by_provider": [
+      {
+        "provider_ref": "provider.apple",
+        "score": 0.66,
+        "label": "High control surface",
+        "explanation": "Apple controls identity, iCloud Drive, Photos, Notes, and device-bound assistant workflows with partial exportability and medium confidence.",
+        "evidence_refs": ["ev.apple.icloud-drive.inventory.v1"]
+      },
+      {
+        "provider_ref": "provider.google",
+        "score": 0.58,
+        "label": "Moderate-high control surface",
+        "explanation": "Google Workspace assets are broadly discoverable, but native documents and assistant workflows require conversion and workflow replacement planning.",
+        "evidence_refs": ["ev.google.takeout.manifest.v1", "ev.google.drive.exportability.v1"]
+      },
+      {
+        "provider_ref": "provider.microsoft",
+        "score": 0.61,
+        "label": "Moderate-high control surface",
+        "explanation": "Microsoft 365 content is accessible through Graph and export paths, but Teams chat and identity dependencies remain significant blockers.",
+        "evidence_refs": ["ev.microsoft.graph.delta.snapshot.v1", "ev.microsoft.teams.export.blocker.v1"]
+      }
+    ]
+  },
+  "blockers": [
+    {
+      "blocker_id": "blocker.apple.photos.partial-export",
+      "provider_ref": "provider.apple",
+      "domain": "photos",
+      "severity": "medium",
+      "description": "Apple Photos library requires staged export and metadata preservation strategy before bulk migration.",
+      "evidence_refs": ["ev.apple.icloud-drive.inventory.v1"]
+    },
+    {
+      "blocker_id": "blocker.google.docs.conversion",
+      "provider_ref": "provider.google",
+      "domain": "office_docs",
+      "severity": "medium",
+      "description": "Google-native Docs/Sheets/Slides require conversion policy, fidelity checks, and canonical target format selection.",
+      "evidence_refs": ["ev.google.drive.exportability.v1"]
+    },
+    {
+      "blocker_id": "blocker.microsoft.teams.chat-export",
+      "provider_ref": "provider.microsoft",
+      "domain": "chat",
+      "severity": "high",
+      "description": "Teams chat exportability is constrained and requires Graph/export policy review before replacement planning.",
+      "evidence_refs": ["ev.microsoft.teams.export.blocker.v1"]
+    }
+  ],
+  "recommendations": [
+    {
+      "recommendation_id": "rec.establish-open-mail-archive",
+      "priority": 1,
+      "description": "Start with Gmail and Outlook export manifests, preserve raw exports, and normalize into an open mail archive before touching hotter collaborative assets.",
+      "expected_sovereignty_gain": 0.18,
+      "depends_on": [],
+      "evidence_refs": ["ev.google.takeout.manifest.v1"]
+    },
+    {
+      "recommendation_id": "rec.office-doc-conversion-pilot",
+      "priority": 2,
+      "description": "Run a 500-document conversion pilot across Google-native and Microsoft Office assets to estimate fidelity risk and processing budget.",
+      "expected_sovereignty_gain": 0.16,
+      "depends_on": ["rec.establish-open-mail-archive"],
+      "evidence_refs": ["ev.google.drive.exportability.v1", "ev.microsoft.graph.delta.snapshot.v1"]
+    },
+    {
+      "recommendation_id": "rec.chat-retention-policy-review",
+      "priority": 3,
+      "description": "Classify Teams chat retention/export constraints and determine whether chat should be archived, summarized, or replaced through a workspace-native room model.",
+      "expected_sovereignty_gain": 0.11,
+      "depends_on": [],
+      "evidence_refs": ["ev.microsoft.teams.export.blocker.v1"]
+    }
+  ],
+  "phase_2_budget_proposal": {
+    "proposal_id": "budget.synthetic-tenant-a.phase-2.v1",
+    "currency": "USD",
+    "estimated_cost": 18500,
+    "waves": [
+      {
+        "wave_id": "wave-1-mail-and-ledgers",
+        "label": "Mail archive and evidence ledger stabilization",
+        "provider_refs": ["provider.google", "provider.microsoft"],
+        "domain_refs": ["mail", "evidence"],
+        "estimated_cost": 4500,
+        "depends_on": []
+      },
+      {
+        "wave_id": "wave-2-office-doc-pilot",
+        "label": "Office document conversion pilot",
+        "provider_refs": ["provider.google", "provider.microsoft"],
+        "domain_refs": ["office_docs"],
+        "estimated_cost": 6500,
+        "depends_on": ["wave-1-mail-and-ledgers"]
+      },
+      {
+        "wave_id": "wave-3-media-and-chat-risk",
+        "label": "Apple media preservation and Teams chat blocker analysis",
+        "provider_refs": ["provider.apple", "provider.microsoft"],
+        "domain_refs": ["photos", "chat"],
+        "estimated_cost": 7500,
+        "depends_on": ["wave-1-mail-and-ledgers"]
+      }
+    ],
+    "evidence_refs": ["ev.apple.icloud-drive.inventory.v1", "ev.google.takeout.manifest.v1", "ev.microsoft.graph.delta.snapshot.v1", "ev.microsoft.teams.export.blocker.v1"]
+  }
+}

--- a/schemas/exodus-run.v0.schema.json
+++ b/schemas/exodus-run.v0.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/exodus/exodus-run.v0.schema.json",
+  "title": "Exodus Run v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "tenant_id",
+    "generated_at",
+    "phase",
+    "demo_boundary",
+    "providers",
+    "accounts",
+    "asset_census",
+    "export_ledger",
+    "scores",
+    "blockers",
+    "recommendations",
+    "phase_2_budget_proposal"
+  ],
+  "properties": {
+    "schema_version": { "const": "exodus.run.v0" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "phase": {
+      "type": "string",
+      "enum": ["phase_1_topology_census", "phase_2_plan_budget"]
+    },
+    "demo_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["synthetic", "live_credentials_required", "destructive_actions_allowed", "provider_side_writes_allowed"],
+      "properties": {
+        "synthetic": { "const": true },
+        "live_credentials_required": { "const": false },
+        "destructive_actions_allowed": { "const": false },
+        "provider_side_writes_allowed": { "const": false },
+        "notes": { "type": "string" }
+      }
+    },
+    "providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/provider" }
+    },
+    "accounts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/account" }
+    },
+    "asset_census": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/asset_census_item" }
+    },
+    "export_ledger": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/export_ledger_item" }
+    },
+    "scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eri", "pcs_by_provider"],
+      "properties": {
+        "eri": { "$ref": "#/$defs/score" },
+        "pcs_by_provider": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/provider_score" }
+        }
+      }
+    },
+    "blockers": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/blocker" }
+    },
+    "recommendations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/recommendation" }
+    },
+    "phase_2_budget_proposal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["proposal_id", "currency", "estimated_cost", "waves", "evidence_refs"],
+      "properties": {
+        "proposal_id": { "type": "string", "minLength": 1 },
+        "currency": { "type": "string", "minLength": 3, "maxLength": 3 },
+        "estimated_cost": { "type": "number", "minimum": 0 },
+        "waves": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["wave_id", "label", "provider_refs", "domain_refs", "estimated_cost", "depends_on"],
+            "properties": {
+              "wave_id": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 },
+              "provider_refs": { "type": "array", "items": { "type": "string" } },
+              "domain_refs": { "type": "array", "items": { "type": "string" } },
+              "estimated_cost": { "type": "number", "minimum": 0 },
+              "depends_on": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  },
+  "$defs": {
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider_id", "name", "domains", "control_surfaces", "confidence"],
+      "properties": {
+        "provider_id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "domains": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "control_surfaces": { "type": "array", "items": { "type": "string" } },
+        "confidence": { "type": "string", "enum": ["low", "medium", "high"] }
+      }
+    },
+    "account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["account_id", "provider_ref", "label", "root_refs"],
+      "properties": {
+        "account_id": { "type": "string", "minLength": 1 },
+        "provider_ref": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "root_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "asset_census_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_collection_id", "provider_ref", "domain", "asset_count", "byte_count", "exportability", "temperature"],
+      "properties": {
+        "asset_collection_id": { "type": "string", "minLength": 1 },
+        "provider_ref": { "type": "string", "minLength": 1 },
+        "domain": { "type": "string", "minLength": 1 },
+        "asset_count": { "type": "integer", "minimum": 0 },
+        "byte_count": { "type": "integer", "minimum": 0 },
+        "exportability": { "type": "string", "enum": ["native_open", "exportable", "partial", "blocked", "unknown"] },
+        "temperature": { "type": "string", "enum": ["hot", "warm", "cold"] }
+      }
+    },
+    "export_ledger_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_id", "provider_ref", "domain", "artifact_class", "hash_sha256", "validation_status"],
+      "properties": {
+        "evidence_id": { "type": "string", "minLength": 1 },
+        "provider_ref": { "type": "string", "minLength": 1 },
+        "domain": { "type": "string", "minLength": 1 },
+        "artifact_class": { "type": "string", "minLength": 1 },
+        "hash_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "validation_status": { "type": "string", "enum": ["synthetic_verified", "pending", "failed"] }
+      }
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "label", "explanation", "evidence_refs"],
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "explanation": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "provider_score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider_ref", "score", "label", "explanation", "evidence_refs"],
+      "properties": {
+        "provider_ref": { "type": "string", "minLength": 1 },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "explanation": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["blocker_id", "provider_ref", "domain", "severity", "description", "evidence_refs"],
+      "properties": {
+        "blocker_id": { "type": "string", "minLength": 1 },
+        "provider_ref": { "type": "string", "minLength": 1 },
+        "domain": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "description": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["recommendation_id", "priority", "description", "expected_sovereignty_gain", "depends_on", "evidence_refs"],
+      "properties": {
+        "recommendation_id": { "type": "string", "minLength": 1 },
+        "priority": { "type": "integer", "minimum": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "expected_sovereignty_gain": { "type": "number", "minimum": 0, "maximum": 1 },
+        "depends_on": { "type": "array", "items": { "type": "string" } },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/scripts/validate_exodus_demo.py
+++ b/scripts/validate_exodus_demo.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Validate the synthetic Exodus Migration Workroom demo fixture.
+
+This validator is intentionally offline. It does not require live provider
+credentials, does not contact Apple/Google/Microsoft, and does not perform any
+destructive or provider-side actions.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "exodus-run.v0.schema.json"
+FIXTURE = ROOT / "examples" / "synthetic-tenant-a" / "exodus-run.json"
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} root must be object")
+    return data
+
+
+def validate_schema(schema: dict[str, Any], fixture: dict[str, Any]) -> str:
+    try:
+        import jsonschema  # type: ignore
+    except Exception:
+        return "skipped_jsonschema_unavailable"
+    jsonschema.Draft202012Validator(schema).validate(fixture)
+    return "valid"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_refs(fixture: dict[str, Any]) -> dict[str, Any]:
+    providers = {p["provider_id"] for p in fixture["providers"]}
+    accounts = {a["account_id"] for a in fixture["accounts"]}
+    evidence = {e["evidence_id"] for e in fixture["export_ledger"]}
+    blockers = {b["blocker_id"] for b in fixture["blockers"]}
+    recommendations = {r["recommendation_id"] for r in fixture["recommendations"]}
+    waves = {w["wave_id"] for w in fixture["phase_2_budget_proposal"]["waves"]}
+
+    require(fixture["demo_boundary"]["synthetic"] is True, "fixture must be synthetic")
+    require(fixture["demo_boundary"]["live_credentials_required"] is False, "live credentials must not be required")
+    require(fixture["demo_boundary"]["destructive_actions_allowed"] is False, "destructive actions must not be allowed")
+    require(fixture["demo_boundary"]["provider_side_writes_allowed"] is False, "provider-side writes must not be allowed")
+
+    expected_providers = {"provider.apple", "provider.google", "provider.microsoft"}
+    require(expected_providers.issubset(providers), f"missing expected providers: {sorted(expected_providers - providers)}")
+
+    for account in fixture["accounts"]:
+        require(account["provider_ref"] in providers, f"account {account['account_id']} has unknown provider_ref")
+    for item in fixture["asset_census"]:
+        require(item["provider_ref"] in providers, f"asset {item['asset_collection_id']} has unknown provider_ref")
+    for item in fixture["export_ledger"]:
+        require(item["provider_ref"] in providers, f"evidence {item['evidence_id']} has unknown provider_ref")
+        require(item["validation_status"] == "synthetic_verified", f"evidence {item['evidence_id']} must be synthetic_verified")
+    for score in fixture["scores"]["pcs_by_provider"]:
+        require(score["provider_ref"] in providers, f"provider score has unknown provider_ref {score['provider_ref']}")
+        for ref in score["evidence_refs"]:
+            require(ref in evidence, f"provider score {score['provider_ref']} references unknown evidence {ref}")
+    for ref in fixture["scores"]["eri"]["evidence_refs"]:
+        require(ref in evidence, f"ERI references unknown evidence {ref}")
+    for blocker in fixture["blockers"]:
+        require(blocker["provider_ref"] in providers, f"blocker {blocker['blocker_id']} has unknown provider_ref")
+        for ref in blocker["evidence_refs"]:
+            require(ref in evidence, f"blocker {blocker['blocker_id']} references unknown evidence {ref}")
+    for rec in fixture["recommendations"]:
+        for dep in rec["depends_on"]:
+            require(dep in recommendations, f"recommendation {rec['recommendation_id']} depends on unknown recommendation {dep}")
+        for ref in rec["evidence_refs"]:
+            require(ref in evidence, f"recommendation {rec['recommendation_id']} references unknown evidence {ref}")
+    for wave in fixture["phase_2_budget_proposal"]["waves"]:
+        for provider in wave["provider_refs"]:
+            require(provider in providers, f"wave {wave['wave_id']} references unknown provider {provider}")
+        for dep in wave["depends_on"]:
+            require(dep in waves, f"wave {wave['wave_id']} depends on unknown wave {dep}")
+    for ref in fixture["phase_2_budget_proposal"]["evidence_refs"]:
+        require(ref in evidence, f"budget proposal references unknown evidence {ref}")
+
+    return {
+        "provider_count": len(providers),
+        "account_count": len(accounts),
+        "asset_collection_count": len(fixture["asset_census"]),
+        "evidence_count": len(evidence),
+        "blocker_count": len(blockers),
+        "recommendation_count": len(recommendations),
+        "budget_wave_count": len(waves),
+    }
+
+
+def main() -> int:
+    try:
+        schema = load(SCHEMA)
+        fixture = load(FIXTURE)
+        schema_status = validate_schema(schema, fixture)
+        counts = validate_refs(fixture)
+    except Exception as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+
+    report = {
+        "schema_version": "exodus.synthetic-workroom-demo.validation.v0",
+        "fixture": "examples/synthetic-tenant-a/exodus-run.json",
+        "schema": "schemas/exodus-run.v0.schema.json",
+        "schema_validation": schema_status,
+        "cross_reference_validation": "valid",
+        "demo_boundary": "synthetic_offline_no_provider_credentials_no_destructive_actions",
+        **counts,
+        "validation_status": "valid"
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements Phase 1 of SocioProphet/sociosphere#478 for the Exodus side of the governed Migration Workroom demo.

Scope:

- add `schemas/exodus-run.v0.schema.json`
- add `examples/synthetic-tenant-a/exodus-run.json`
- add `scripts/validate_exodus_demo.py`
- wire the validator into existing CI
- add `docs/synthetic-workroom-demo.md`

What this proves:

- Exodus can represent a deterministic synthetic Apple/Google/Microsoft exit-readiness run
- fixture includes provider topology, account/root inventory, asset census, export ledger, ERI/PCS scores, blockers, recommendations, and Phase 2 budget proposal
- offline validator checks schema shape where `jsonschema` is available and always checks synthetic boundary plus cross-references

Non-goals:

- no live Apple/Google/Microsoft credentials
- no provider API calls
- no destructive actions
- no provider-side writes
- no production migration claim
- no UI readiness claim

Related:

- SocioProphet/sociosphere#478
