### PR TITLE
sanitize(fixture): scrub real-case filename from valid-evidence-artifact example

### DIFF
--- a/examples/valid-evidence-artifact.json
+++ b/examples/valid-evidence-artifact.json
@@ -2,7 +2,7 @@
   "artifact_id": "018f3f72-6b79-7c35-8f7d-4a3a7d2d0001",
   "corpus_id": "SP-FORENSICS-2026",
   "exhibit_id": "AF-0001",
-  "original_filename": "console faults.rtf",
+  "original_filename": "synthetic-console-log.rtf",
   "mime_type": "text/rtf",
   "file_size_bytes": 1024,
   "artifact_class": "ConsolePaste",
@@ -31,10 +31,18 @@
   "chain_of_trust": [],
   "evidence_class": "Primary",
   "evidence_grade": "E3",
-  "layer_citations": ["L07-Identity"],
-  "hypothesis_ids": ["HYP-FIXTURE-001"],
-  "null_hypothesis_ids": ["NULL-FIXTURE-001"],
-  "counter_explanations": ["Synthetic fixture, not real evidence."],
+  "layer_citations": [
+    "L07-Identity"
+  ],
+  "hypothesis_ids": [
+    "HYP-FIXTURE-001"
+  ],
+  "null_hypothesis_ids": [
+    "NULL-FIXTURE-001"
+  ],
+  "counter_explanations": [
+    "Synthetic fixture, not real evidence."
+  ],
   "security_label": "Internal",
   "witness_retention": "LocalOnly",
   "owning_zone": "Landing",


### PR DESCRIPTION
Removes the last real-case data string on `main`: `examples/valid-evidence-artifact.json` carried `original_filename: "console faults.rtf"` (pre-existing, not from #20). Everything else in the fixture is already synthetic. Forward-scrubbed to `synthetic-console-log.rtf`.

**History note:** the value was already public on `main`, so it persists in git history. A full scrub needs a history rewrite (git-filter-repo/BFG) — a separate deliberate op since it rewrites public history and forces re-clones. Flagging for your decision.